### PR TITLE
Bug fix in write logic for dcon.out and crit.out

### DIFF
--- a/examples/DIIID_ideal_example/dcon.toml
+++ b/examples/DIIID_ideal_example/dcon.toml
@@ -44,7 +44,7 @@ termbycross_flag = false      # Terminate ODE solver in the event of a zero cros
 use_classic_splines = false   # Use a classical cubic spline instead of tri-diagonal solution
 
 [DCON_OUTPUT]
-write_crit_out = false         # Write crit.out which contains integration data
-write_dcon_out = false         # Write dcon.out which contains equilibrium data and final eigenvalues/vectors
+write_crit_out = true         # Write crit.out which contains integration data
+write_dcon_out = true         # Write dcon.out which contains equilibrium data and final eigenvalues/vectors
 write_euler_h5 = true         # Write euler.h5 (euler.bin Julia equivalent)
 write_eqdata_h5 = true        # Write eqdata.h5, which contains profile and stability data

--- a/examples/DIIID_ideal_example/dcon.toml
+++ b/examples/DIIID_ideal_example/dcon.toml
@@ -44,7 +44,7 @@ termbycross_flag = false      # Terminate ODE solver in the event of a zero cros
 use_classic_splines = false   # Use a classical cubic spline instead of tri-diagonal solution
 
 [DCON_OUTPUT]
-write_crit_out = true         # Write crit.out which contains integration data
-write_dcon_out = true         # Write dcon.out which contains equilibrium data and final eigenvalues/vectors
+write_crit_out = false         # Write crit.out which contains integration data
+write_dcon_out = false         # Write dcon.out which contains equilibrium data and final eigenvalues/vectors
 write_euler_h5 = true         # Write euler.h5 (euler.bin Julia equivalent)
 write_eqdata_h5 = true        # Write eqdata.h5, which contains profile and stability data

--- a/src/DCON/Free.jl
+++ b/src/DCON/Free.jl
@@ -203,41 +203,43 @@ function free_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit:
             ", real = ", real(et[1]), ", imaginary = ", imag(et[1]))
     end
 
-    # Write eigenvalues to file
-    write_output(outp, :dcon_out, "\nTotal Energy Eigenvalues:")
-    write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
-    for isol in 1:intr.mpert
-        write_output(outp, :dcon_out, @sprintf("%6d %11.3e %11.3e %11.3e %11.3e",
-            isol, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
-    end
-    write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
-
-    # Write eigenvectors to file
-    write_output(outp, :dcon_out, "Total Energy Eigenvectors:")
-    m = intr.mlow .+ collect(0:intr.mpert-1)
-    for isol in 1:intr.mpert
-        write_output(outp, :dcon_out, "\n   isol   imax   plasma      vacuum   re total   im total\n")
-        write_output(outp, :dcon_out, @sprintf("%6d %6d %11.3e %11.3e %11.3e %11.3e",
-            isol, imax, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
-        write_output(outp, :dcon_out, "\n  ipert     m      re wt      im wt      abs wt\n")
-        for ipert in 1:intr.mpert
-            write_output(outp, :dcon_out,
-                @sprintf("%6d %6d %11.3e %11.3e %11.3e %s",
-                    ipert, m[ipert], real(wt[ipert, isol]), imag(wt[ipert, isol]), abs(wt[ipert, isol]), star[ipert, isol]))
+    if outp.write_dcon_out
+        # Write eigenvalues to file
+        write_output(outp, :dcon_out, "\nTotal Energy Eigenvalues:")
+        write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
+        for isol in 1:intr.mpert
+            write_output(outp, :dcon_out, @sprintf("%6d %11.3e %11.3e %11.3e %11.3e",
+                isol, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
         end
-        write_output(outp, :dcon_out, "\n  ipert     m      re wt      im wt      abs wt\n")
-    end
+        write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
 
-    # Write the plasma matrix.
-    write_output(outp, :dcon_out, "Plasma Energy Matrix:\n")
-    for isol in 1:intr.mpert
-        write_output(outp, :dcon_out, "isol = $(isol), m = $(m[isol])")
-        write_output(outp, :dcon_out, "\n  i     re wp        im wp        abs wp\n")
-        for ipert in 1:intr.mpert
-            write_output(outp, :dcon_out, @sprintf("%3d%13.5e%13.5e%13.5e",
-                ipert, real(wp[ipert, isol]), imag(wp[ipert, isol]), abs(wp[ipert, isol])))
+        # Write eigenvectors to file
+        write_output(outp, :dcon_out, "Total Energy Eigenvectors:")
+        m = intr.mlow .+ collect(0:intr.mpert-1)
+        for isol in 1:intr.mpert
+            write_output(outp, :dcon_out, "\n   isol   imax   plasma      vacuum   re total   im total\n")
+            write_output(outp, :dcon_out, @sprintf("%6d %6d %11.3e %11.3e %11.3e %11.3e",
+                isol, imax, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
+            write_output(outp, :dcon_out, "\n  ipert     m      re wt      im wt      abs wt\n")
+            for ipert in 1:intr.mpert
+                write_output(outp, :dcon_out,
+                    @sprintf("%6d %6d %11.3e %11.3e %11.3e %s",
+                        ipert, m[ipert], real(wt[ipert, isol]), imag(wt[ipert, isol]), abs(wt[ipert, isol]), star[ipert, isol]))
+            end
+            write_output(outp, :dcon_out, "\n  ipert     m      re wt      im wt      abs wt\n")
         end
-        write_output(outp, :dcon_out, "\n  i     re wp        im wp        abs wp\n")
+
+        # Write the plasma matrix to file
+        write_output(outp, :dcon_out, "Plasma Energy Matrix:\n")
+        for isol in 1:intr.mpert
+            write_output(outp, :dcon_out, "isol = $(isol), m = $(m[isol])")
+            write_output(outp, :dcon_out, "\n  i     re wp        im wp        abs wp\n")
+            for ipert in 1:intr.mpert
+                write_output(outp, :dcon_out, @sprintf("%3d%13.5e%13.5e%13.5e",
+                    ipert, real(wp[ipert, isol]), imag(wp[ipert, isol]), abs(wp[ipert, isol])))
+            end
+            write_output(outp, :dcon_out, "\n  i     re wp        im wp        abs wp\n")
+        end
     end
 
     # Compute separate plasma and vacuum eigenvalues.

--- a/src/DCON/Ode.jl
+++ b/src/DCON/Ode.jl
@@ -475,8 +475,10 @@ function ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.
         singp = intr.sing[odet.ising] # Update singp
         odet.psimax = singp.psifac - ctrl.singfac_min / abs(ctrl.nn * singp.q1)
         odet.m1 = round(Int, ctrl.nn * singp.q, RoundFromZero)
-        write_output(outp, :crit_out, @sprintf("   ising   psi         q          di      re alpha   im alpha\n"))
-        write_output(outp, :crit_out, @sprintf("%6d%11.3e%11.3e%11.3e%11.3e%11.3e\n", odet.ising, singp.psifac, singp.q, singp.di, real(singp.alpha), imag(singp.alpha)))
+        if outp.write_crit_out
+            write_output(outp, :crit_out, @sprintf("   ising   psi         q          di      re alpha   im alpha\n"))
+            write_output(outp, :crit_out, @sprintf("%6d%11.3e%11.3e%11.3e%11.3e%11.3e\n", odet.ising, singp.psifac, singp.q, singp.di, real(singp.alpha), imag(singp.alpha)))
+        end
     end
 
     # Restart ode solver
@@ -488,7 +490,9 @@ function ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.
     odet.psi_prev = odet.psifac
 
     # Write next header before continuing integration
-    write_output(outp, :crit_out, "    psifac      dpsi        q       singfac     eval1")
+    if outp.write_crit_out
+        write_output(outp, :crit_out, "    psifac      dpsi        q       singfac     eval1")
+    end
 end
 
 # Example stub for kinetic crossing

--- a/src/DCON/OdeOutput.jl
+++ b/src/DCON/OdeOutput.jl
@@ -107,10 +107,14 @@ function ode_output_init(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium
     # Write crit.out header
     if odet.ising > 0 && odet.ising <= intr.msing
         singp = intr.sing[odet.ising]
-        write_output(outp, :crit_out, @sprintf("   ising   psi         q          di      re alpha   im alpha\n"))
-        write_output(outp, :crit_out, @sprintf("%6d%11.3e%11.3e%11.3e%11.3e%11.3e\n", odet.ising, singp.psifac, singp.q, singp.di, real(singp.alpha), imag(singp.alpha)))
+        if outp.write_crit_out
+            write_output(outp, :crit_out, @sprintf("   ising   psi         q          di      re alpha   im alpha\n"))
+            write_output(outp, :crit_out, @sprintf("%6d%11.3e%11.3e%11.3e%11.3e%11.3e\n", odet.ising, singp.psifac, singp.q, singp.di, real(singp.alpha), imag(singp.alpha)))
+        end
     end
-    write_output(outp, :crit_out, "    psifac      dpsi        q       singfac     eval1\n")
+    if outp.write_crit_out
+        write_output(outp, :crit_out, "    psifac      dpsi        q       singfac     eval1\n")
+    end
 end
 
 """
@@ -181,9 +185,13 @@ function ode_output_monitor(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibr
         if (crit_med - crit) * (crit_med - odet.crit_prev) < 0 &&
            abs(crit_med) < 0.5 * min(abs(crit), abs(odet.crit_prev))
             println("Zero crossing detected at psi = $psi_med, q = $q_med")
-            write_output(outp, :dcon_out, @sprintf("Zero crossing at psi = %10.3e, q = %10.3e", psi_med, q_med))
-            write_output(outp, :crit_out, @sprintf("Zero crossing at psi = %10.3e, q = %10.3e", psi_med, q_med))
-            write_output(outp, :crit_out, @sprintf("%11.3e%11.3e%11.3e%11.3e%11.3e", psi_med, dpsi, q_med, singfac_med, crit_med))
+            if outp.write_dcon_out
+                write_output(outp, :dcon_out, @sprintf("Zero crossing at psi = %10.3e, q = %10.3e", psi_med, q_med))
+            end
+            if outp.write_crit_out
+                write_output(outp, :crit_out, @sprintf("Zero crossing at psi = %10.3e, q = %10.3e", psi_med, q_med))
+                write_output(outp, :crit_out, @sprintf("%11.3e%11.3e%11.3e%11.3e%11.3e", psi_med, dpsi, q_med, singfac_med, crit_med))
+            end
             odet.nzero += 1
         end
         if ctrl.termbycross_flag
@@ -194,7 +202,9 @@ function ode_output_monitor(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibr
     end
 
     # Write new crit
-    write_output(outp, :crit_out, @sprintf("%11.3e%11.3e%11.3e%11.3e%11.3e", odet.psifac, dpsi, odet.q, singfac, crit))
+    if outp.write_crit_out
+        write_output(outp, :crit_out, @sprintf("%11.3e%11.3e%11.3e%11.3e%11.3e", odet.psifac, dpsi, odet.q, singfac, crit))
+    end
 
     # Update saved values
     odet.psi_prev = odet.psifac

--- a/src/DCON/Sing.jl
+++ b/src/DCON/Sing.jl
@@ -5,12 +5,16 @@ Scan all singular surfaces and calculate asymptotic vmat and mmat matrices
 and Mericer criterion. Performs the same function as `sing_scan` in the Fortran code.
 """
 function sing_scan!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, outp::DconOutput)
-    write_output(outp, :dcon_out, "\n Singular Surfaces:")
-    write_output(outp, :dcon_out, @sprintf("%3s %11s %11s %11s %11s %11s %11s %11s", "i", "psi", "rho", "q", "q1", "di0", "di", "err"))
+    if outp.write_dcon_out
+        write_output(outp, :dcon_out, "\n Singular Surfaces:")
+        write_output(outp, :dcon_out, @sprintf("%3s %11s %11s %11s %11s %11s %11s %11s", "i", "psi", "rho", "q", "q1", "di0", "di", "err"))
+    end
     for ising in 1:intr.msing
         sing_vmat!(intr, ctrl, equil, ffit, outp, ising)
     end
-    write_output(outp, :dcon_out, @sprintf("%3s %11s %11s %11s %11s %11s %11s %11s", "i", "psi", "rho", "q", "q1", "di0", "di", "err"))
+    if outp.write_dcon_out
+        write_output(outp, :dcon_out, @sprintf("%3s %11s %11s %11s %11s %11s %11s %11s", "i", "psi", "rho", "q", "q1", "di0", "di", "err"))
+    end
 end
 
 """
@@ -188,7 +192,9 @@ function sing_vmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
     singp.power[ipert0] = -singp.alpha
     singp.power[ipert0+intr.mpert] = singp.alpha
 
-    write_output(outp, :dcon_out, @sprintf("%3d %11.3e %11.3e %11.3e %11.3e %11.3e %11.3e %11.3e", ising, psifac, rho, q, q1, di0, singp.di, singp.di / di0 - 1))
+    if outp.write_dcon_out
+        write_output(outp, :dcon_out, @sprintf("%3d %11.3e %11.3e %11.3e %11.3e %11.3e %11.3e %11.3e", ising, psifac, rho, q, q1, di0, singp.di, singp.di / di0 - 1))
+    end
 
     # Zeroth-order non-resonant solutions
     singp.vmat .= 0


### PR DESCRIPTION
I had forgotten to add if statements to check if `write_dcon_out` and `write_crit_out` are true before trying to write to the files, so the code would try to write to files that didn't exist if either of these two were false and the code would error out. This (very minor) PR fixes that by wrapping these write lines in if statements so the code can be run without dumping to the .out files. All I did (and that was needed to test this) was running the DIIID ideal example with `write_dcon_out` and `write_crit_out` set to false and confirming the files weren't created and the code ran through without erroring out