### PR TITLE
Equilibrium Bugfixes

### DIFF
--- a/src/DCON/OdeOutput.jl
+++ b/src/DCON/OdeOutput.jl
@@ -251,7 +251,7 @@ function ode_output_get_crit(psi::Float64, u::Array{ComplexF64,3}, mpert::Int, m
     singfac = abs(m1 - nn * profiles[4])
     logpsi1 = log10(psi)
     logsingfac = log10(singfac)
-    crit = evalsi[indexi[1]] # * profiles[3]^2 # TODO: appears to be a bug in profiles[3]
+    crit = evalsi[indexi[1]]* profiles[3]^2
 
     return q, singfac, logpsi1, logsingfac, crit
 end

--- a/src/DCON/OdeOutput.jl
+++ b/src/DCON/OdeOutput.jl
@@ -224,7 +224,6 @@ A tuple `(q, singfac, logpsi1, logsingfac, crit)` of critical data for the time 
 
 ### TODOs
 
-Add dVdpsi multiplication back once equilibrium bug is fixed
 Decide if we want to just pass in the relevant quantities instead of structs for functions like this
 """
 function ode_output_get_crit(psi::Float64, u::Array{ComplexF64,3}, mpert::Int, m1::Int, nn::Int, sq::Spl.CubicSpline)

--- a/src/Equilibrium/AnalyticEquilibrium.jl
+++ b/src/Equilibrium/AnalyticEquilibrium.jl
@@ -207,7 +207,7 @@ function lar_run(equil_input::EquilibriumConfig, lar_input::LargeAspectRatioConf
 end
 
 """
-This function handles the Soloviev analytical equilibrium model, transforming the input parameters
+This function handles the Solovev analytical equilibrium model, transforming the input parameters
 into the necessary splines and scalar values for equilibrium construction. This is a Julia version
 of the Fortran code in sol.f, with no major differences except for arrays going from 0:n to 1:n+1.
 
@@ -228,7 +228,7 @@ of the Fortran code in sol.f, with no major differences except for arrays going 
 
   - `DirectRunInput` object
 """
-function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolevevConfig)
+function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolovevConfig)
 
     mr = sol_inputs.mr
     mz = sol_inputs.mz
@@ -278,7 +278,7 @@ function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolevevConfig)
     psi_in = Spl.BicubicSpline(r, z, psifs; bctypex=3, bctypey=3)
 
     # Print out equilibrium info
-    println("Generating Soloviev equilibrium inputs with:")
+    println("Generating Solovev equilibrium inputs with:")
     println("   mr=$mr, mz=$mz, ma=$ma")
     println("   e=$e, a=$a, r0=$r0")
     println("   q0=$q0, p0fac=$p0fac, b0fac=$b0fac, f0fac=$f0fac")

--- a/src/Equilibrium/AnalyticEquilibrium.jl
+++ b/src/Equilibrium/AnalyticEquilibrium.jl
@@ -265,7 +265,7 @@ function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolevevConfig)
     sqfs[:, 2] .= pfac .* (1 .* p0fac .- psis)
     sqfs[:, 3] .= 0.0
     sq_in = Spl.CubicSpline(psis, sqfs; bctype=3)
-    
+
     # Compute 2D data and spline
     r = [rmin + i * (rmax - rmin) / mr for i in 0:mr]
     z = [zmin + j * (zmax - zmin) / mz for j in 0:mz]

--- a/src/Equilibrium/AnalyticEquilibrium.jl
+++ b/src/Equilibrium/AnalyticEquilibrium.jl
@@ -149,7 +149,7 @@ function lar_run(equil_input::EquilibriumConfig, lar_input::LargeAspectRatioConf
 
     xs_r = temp[:, 1]
     fs_r = temp[:, 2:9]
-    spl = Spl.CubicSpline(xs_r, fs_r; bctype=4)
+    spl = Spl.CubicSpline(xs_r, fs_r; bctype="extrap")
 
     dr = lar_a / (ma + 1)
     r = 0.0
@@ -175,7 +175,7 @@ function lar_run(equil_input::EquilibriumConfig, lar_input::LargeAspectRatioConf
         sq_fs[ia, 3] = qval
     end
 
-    sq_in = Spl.CubicSpline(sq_xs, sq_fs; bctype=4)
+    sq_in = Spl.CubicSpline(sq_xs, sq_fs; bctype="extrap")
 
     rzphi_y_nodes = range(0.0, 2π; length=mtau + 1)
     rzphi_fs_nodes = zeros(ma + 1, mtau + 1, 2)
@@ -200,7 +200,7 @@ function lar_run(equil_input::EquilibriumConfig, lar_input::LargeAspectRatioConf
         end
     end
 
-    rz_in = Spl.BicubicSpline(r_nodes, collect(rzphi_y_nodes), rzphi_fs_nodes; bctypex=4, bctypey=2)
+    rz_in = Spl.BicubicSpline(r_nodes, collect(rzphi_y_nodes), rzphi_fs_nodes; bctypex="extrap", bctypey="periodic")
 
     return InverseRunInput(equil_input, sq_in, rz_in, lar_r0, 0.0, psio)
 
@@ -264,7 +264,7 @@ function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolovevConfig)
     sqfs[:, 1] .= f0 .* f0fac
     sqfs[:, 2] .= pfac .* (1 .* p0fac .- psis)
     sqfs[:, 3] .= 0.0
-    sq_in = Spl.CubicSpline(psis, sqfs; bctype=3)
+    sq_in = Spl.CubicSpline(psis, sqfs; bctype="extrap")
 
     # Compute 2D data and spline
     r = [rmin + i * (rmax - rmin) / mr for i in 0:mr]
@@ -275,7 +275,7 @@ function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolovevConfig)
             psifs[ir, iz, 1] = psio - psifac * (efac * (r[ir] * z[iz])^2 + (r[ir]^2 - r0^2)^2 / 4)
         end
     end
-    psi_in = Spl.BicubicSpline(r, z, psifs; bctypex=3, bctypey=3)
+    psi_in = Spl.BicubicSpline(r, z, psifs; bctypex="extrap", bctypey="extrap")
 
     # Print out equilibrium info
     println("Generating Solovev equilibrium inputs with:")

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -559,7 +559,7 @@ function equilibrium_solver(raw_profile::DirectRunInput)
         # e. Store surface-averaged quantities for the `sq` spline
         sq_fs_nodes[ipsi, 1] = bf_start.f * (2pi) # 2pi*F
         sq_fs_nodes[ipsi, 2] = bf_start.p
-        sq_fs_nodes[ipsi, 3] = y_out[end, 5] * (2pi) * psio # dV/d(psi)
+        sq_fs_nodes[ipsi, 3] = y_out[end, 2] * (2pi) * psio # dV/d(psi)
         sq_fs_nodes[ipsi, 4] = y_out[end, 4] * bf_start.f / (2pi) # q-profile
     end
     println("...Loop over flux surfaces finished.")

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -217,7 +217,7 @@ function direct_position(
     new_psi_fs = psi_in.fs * fac
     x_coords = Vector(psi_in.xs)
     y_coords = Vector(psi_in.ys)
-    psi_in_new = Spl.BicubicSpline(x_coords, y_coords, new_psi_fs; bctypex=4, bctypey=4)
+    psi_in_new = Spl.BicubicSpline(x_coords, y_coords, new_psi_fs; bctypex="extrap", bctypey="extrap")
 
     if abs(psi_at_axis - psio) / psio > 1e-3
         @warn "Psi at located axis (O-point) differs from expected psio. " *
@@ -565,7 +565,7 @@ function equilibrium_solver(raw_profile::DirectRunInput)
     println("...Loop over flux surfaces finished.")
 
     # 5. Finalize splines and perform q-profile revision if needed
-    sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype=4)
+    sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype="extrap")
 
     if equil_params.newq0 != 0.0
         println("Revising q-profile for newq0 = $(equil_params.newq0)...")
@@ -585,13 +585,13 @@ function equilibrium_solver(raw_profile::DirectRunInput)
             rzphi_fs_nodes[i, :, 3] .*= ffac # Toroidal stream function
         end
         # Re-create the spline with the revised data
-        sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype=4)
+        sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype="extrap")
         println("...q-profile revision complete.")
     end
 
     # Create the final geometric spline `rzphi`. Periodic in theta (y-dimension)
     rzphi_y_nodes = range(0.0, 1.0; length=mtheta + 1)
-    rzphi = Spl.BicubicSpline(sq_x_nodes, collect(rzphi_y_nodes), rzphi_fs_nodes; bctypex=4, bctypey=2)
+    rzphi = Spl.BicubicSpline(sq_x_nodes, collect(rzphi_y_nodes), rzphi_fs_nodes; bctypex="extrap", bctypey="periodic")
     println("Final geometric spline 'rzphi' is fitted.")
 
     # 6. Calculate final physics quantities (B-field, metric components, etc.)
@@ -647,7 +647,7 @@ function equilibrium_solver(raw_profile::DirectRunInput)
     end
     println("...done.")
 
-    eqfun = Spl.BicubicSpline(sq_x_nodes, collect(rzphi_y_nodes), eqfun_fs_nodes; bctypex=4, bctypey=2)
+    eqfun = Spl.BicubicSpline(sq_x_nodes, collect(rzphi_y_nodes), eqfun_fs_nodes; bctypex="extrap", bctypey="periodic")
 
     println("--- Direct Equilibrium Processing Finished ---")
 

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -435,7 +435,7 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
 
 
 
-    flux = Spl.BicubicSpline(collect(rzphi.xs), collect(rzphi.ys), flux_fs; bctypex="periodic", bctypey="periodic")
+    flux = Spl.BicubicSpline(collect(rzphi.xs), collect(rzphi.ys), flux_fs; bctypex="extrap", bctypey="periodic")
 
     source = zeros(Float64, mpsi + 1, mtheta + 1)
     for ipsi in 0:mpsi

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -63,7 +63,7 @@ function setup_equilibrium(eq_config::EquilibriumConfig, additional_input=nothin
     elseif eq_type == "sol"
 
         if additional_input === nothing
-            additional_input = SolevevConfig(eq_config.control.eq_filename)
+            additional_input = SolovevConfig(eq_config.control.eq_filename)
         end
 
         eq_input = sol_run(eq_config, additional_input)

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -435,7 +435,7 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
 
 
 
-    flux = Spl.BicubicSpline(collect(rzphi.xs), collect(rzphi.ys), flux_fs; bctypex=2, bctypey=2)
+    flux = Spl.BicubicSpline(collect(rzphi.xs), collect(rzphi.ys), flux_fs; bctypex="periodic", bctypey="periodic")
 
     source = zeros(Float64, mpsi + 1, mtheta + 1)
     for ipsi in 0:mpsi
@@ -473,7 +473,7 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
         fs_matrix[:, 1] = flux.fsx[ipsi+1, :, 1]
         fs_matrix[:, 2] = source[ipsi+1, :]
 
-        spline = Spl.CubicSpline(Vector(flux.ys), fs_matrix; bctype=2)
+        spline = Spl.CubicSpline(Vector(flux.ys), fs_matrix; bctype="periodic")
         Spl.spline_integrate!(spline)
 
         term[ipsi+1, :] .= spline.fsi[end, :]

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -195,7 +195,7 @@ end
 
 
 """
-    SolevevConfig(...)
+    SolovevConfig(...)
 
 A mutable struct holding parameters for the Solev'ev (SOL) plasma equilibrium model.
 
@@ -212,7 +212,7 @@ A mutable struct holding parameters for the Solev'ev (SOL) plasma equilibrium mo
   - `b0fac`: scale toroidal field at constant beta (s*Phi,s*f,s^2*P. bt changes. Shape,beta constant)
   - `f0fac`: scale toroidal field at constant pressure (s*f. beta,q changes. Phi,p,bp constant)
 """
-@kwdef mutable struct SolevevConfig
+@kwdef mutable struct SolovevConfig
     mr::Int = 128      # number of radial grid zones
     mz::Int = 128      # number of axial grid zones
     ma::Int = 128      # number of flux grid zones
@@ -229,10 +229,10 @@ end
 Outer constructor for LarConfig that enables a toml file
 interface for specifying the configuration settings
 """
-function SolevevConfig(path::String) # if we use @kwdef, it generates SolevevConfig() so it conflicts with this line.
+function SolovevConfig(path::String) # if we use @kwdef, it generates SolovevConfig() so it conflicts with this line.
     raw = TOML.parsefile(path)
     input_data = get(raw, "SOL_INPUT", Dict())
-    return SolevevConfig(; symbolize_keys(input_data)...)
+    return SolovevConfig(; symbolize_keys(input_data)...)
 end
 
 

--- a/src/Equilibrium/ReadEquilibrium.jl
+++ b/src/Equilibrium/ReadEquilibrium.jl
@@ -266,7 +266,7 @@ function read_chease2(config::EquilibriumConfig)
 
 
     # Setup bicubic spline with periodic boundary conditions
-    rz_in = Spl.BicubicSpline(xs, ys, fs; bctypex="periodic", bctypey="periodic")
+    rz_in = Spl.BicubicSpline(xs, ys, fs; bctypex="extrap", bctypey="periodic")
     println("--> Finished reading CHEASE equilibrium.")
     println("    Magnetic axis at (ro=$ro, zo=$zo), psio=$psio")
     return InverseRunInput(config, sq_in, rz_in, ro, zo, psio)
@@ -401,7 +401,7 @@ function read_chease(config::EquilibriumConfig)
         ys = range(0, 2π; length=mtau) |> collect
 
         # Setup bicubic spline with periodic boundary conditions
-        rz_in = Spl.bicube_setup(xs, ys, fs; bctypex="periodic", bctypey="periodic")
+        rz_in = Spl.bicube_setup(xs, ys, fs; bctypex="extrap", bctypey="periodic")
 
         if diagnostics
             # --- Print first 5 and last 5 entries of each slice ---

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ else
     include("./runtests_build.jl")
     include("./runtests_spline.jl")
     include("./runtests_vacuum_fortran.jl")
+    include("./runtests_solovev.jl")
     include("./runtests_ode.jl")
     include("./runtests_sing.jl")
 end

--- a/test/runtests_solovev.jl
+++ b/test/runtests_solovev.jl
@@ -1,0 +1,104 @@
+using Test
+using JPEC
+
+# --- Helper constructors ---
+# Minimal valid inputs
+function make_inputs(; mr=4, mz=4, ma=4, e=1.7, a=0.3, r0=1.7, q0=1.0, 
+                      p0fac=1.2, b0fac=1.0, f0fac=1.0)
+    equil_inputs = JPEC.Equilibrium.EquilibriumConfig()  # or mock/minimal constructor
+    sol_inputs = JPEC.Equilibrium.SolovevConfig(mr, mz, ma, e, a, r0, q0, p0fac, b0fac, f0fac)
+    return equil_inputs, sol_inputs
+end
+
+@testset "sol_run basic functionality" begin
+    equil_inputs, sol_inputs = make_inputs()
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+
+    @test isa(dri, JPEC.Equilibrium.DirectRunInput)
+    @test hasproperty(dri, :sq_in)
+    @test hasproperty(dri, :psi_in)
+    @test hasproperty(dri, :rmin)
+    @test hasproperty(dri, :zmax)
+end
+
+@testset "sol_run clamps p0fac to ≥ 1" begin
+    equil_inputs, sol_inputs = make_inputs(p0fac=0.5)
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    @test all(dri.sq_in.fs[:, 2] .>= 0)  # no negative pressures
+end
+
+@testset "sol_run scalar relationships" begin
+    equil_inputs, sol_inputs = make_inputs()
+    mr, mz, ma = sol_inputs.mr, sol_inputs.mz, sol_inputs.ma
+    e, a, r0, q0 = sol_inputs.e, sol_inputs.a, sol_inputs.r0, sol_inputs.q0
+    p0fac, b0fac, f0fac = sol_inputs.p0fac, sol_inputs.b0fac, sol_inputs.f0fac
+
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+
+    # Derived quantities consistency
+    f0_expected = r0 * b0fac
+    psio_expected = e * f0_expected * a * a / (2 * q0 * r0)
+
+    @test isapprox(dri.psio, psio_expected; rtol=1e-10)
+
+    # Range symmetry
+    @test isapprox(dri.zmax, -dri.zmin)
+    @test dri.rmax > dri.rmin
+
+    # Proper grid size consistency
+    @test length(dri.psi_in.xs) == mr + 1
+end
+
+@testset "sol_run spline integrity" begin
+    equil_inputs, sol_inputs = make_inputs(mr=6, mz=5, ma=3)
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    sq = dri.sq_in
+    psi = dri.psi_in
+
+    # Spline types
+    @test isa(sq, JPEC.Spl.CubicSpline)
+    @test isa(psi, JPEC.Spl.BicubicSpline)
+
+    # Domain monotonicity
+    @test issorted(sq.xs)
+    @test issorted(psi.xs)
+    @test issorted(psi.ys)
+
+    # Check that psi values are finite
+    @test all(isfinite, psi.fs)
+end
+
+@testset "sol_run 2D psi field properties" begin
+    equil_inputs, sol_inputs = make_inputs(mr=3, mz=3)
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    psi = dri.psi_in
+
+    # Check psi symmetry in z
+    z_half = Int(length(psi.ys) ÷ 2)
+    vals_top = psi.fs[:, end, 1]
+    vals_bottom = psi.fs[:, 1, 1]
+    @test all(abs.(vals_top .- vals_bottom) .< 1e-12)  # nearly symmetric about z=0
+end
+
+@testset "sol_run parameter sensitivity" begin
+    equil_inputs, sol_inputs = make_inputs()
+    dri1 = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    dri2 = JPEC.Equilibrium.sol_run(equil_inputs, JPEC.Equilibrium.SolovevConfig(sol_inputs.mr, sol_inputs.mz, sol_inputs.ma,
+                                               sol_inputs.e * 1.1, sol_inputs.a, sol_inputs.r0,
+                                               sol_inputs.q0, sol_inputs.p0fac, sol_inputs.b0fac,
+                                               sol_inputs.f0fac))
+    @test dri1.psio != dri2.psio  # psio should depend on elongation e
+end
+
+@testset "sol_run extreme inputs" begin
+    # minimal grid
+    equil_inputs, sol_inputs = make_inputs(mr=1, mz=1, ma=1)
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    @test length(dri.psi_in.xs) == 2
+    @test length(dri.psi_in.ys) == 2
+
+    # very high aspect ratio
+    equil_inputs, sol_inputs = make_inputs(e=0.8, a=0.1, r0=10.0)
+    dri = JPEC.Equilibrium.sol_run(equil_inputs, sol_inputs)
+    @test isfinite(dri.psio)
+end


### PR DESCRIPTION
## Bottom Line
This PR addresses some bugs that I've seen popping up in the equilibrium spline knots and documented in #45
With these fixes, I believe the Solovev ideal example is pretty much fully debugged. We achieve great agreement with the Fortran
Julia (develop)
```
Energies: plasma = -24.07138095505862, vacuum = 13.894868338457542, real = -10.176512616601226, imaginary = 1.956812717198786e-8
```
Julia (this branch)
```
Energies: plasma = -15.557902930443888, vacuum = 8.98058256781093, real = -6.577320362633082, imaginary = 7.043038782294978e-9
```
Fortran
```
 Energies: plasma = -1.556E+01, vacuum =  8.981E+00, real = -6.578E+00, imaginary = -2.657E-07
```
## Details
### `sol_run`
Arrays were only going to `mr/ma/mz` instead of `mr/ma/mz +1`, essentially leaving off the last grid point in these splines. For reference, we can clearly see in the Fortran that both the max and min value should be in these arrays
<img width="389" height="53" alt="image" src="https://github.com/user-attachments/assets/e3dd8a0c-8792-461f-aee6-4cc9b98dab6d" />
I fixed this issue and cleaned up the code and docstring in this section since a lot of lines were unused. Here is a before and after for the fix of printing out some relevant values:
Before
<img width="711" height="102" alt="image" src="https://github.com/user-attachments/assets/d1a94267-7d37-446e-aac1-3910fea08cb2" />
After (we can see that psi, r, and z now contain their max value)
<img width="710" height="101" alt="image" src="https://github.com/user-attachments/assets/f306b334-aa72-4c49-99e2-9ab4a5ed40c4" />

I also added a semi-comprehensive suite of AI generated unit tests for `sol_run` to try to get this trend going (i.e. find a bug, fix it, add unit tests)

### `direct_run`
As mentioned in #45, the `dV/dPsi` values in the spline were extremely off in the splines. To demonstrate this, I wrote a short script that processes the dumped spline nodes for both Fortran and Julia. For the Solovev ideal case (with fixed `sol_run`), I get
<img width="514" height="349" alt="image" src="https://github.com/user-attachments/assets/47217633-fd8d-486c-9458-b6c4c5c53aba" />
(note that column 3 of the sq nodes is dV/dpsi). To fix this bug, I found an indexing issue in this line
`sq_fs_nodes[ipsi, 3] = y_out[end, 5] * (2pi) * psio # dV/d(psi)`, which should actually be
`sq_fs_nodes[ipsi, 3] = y_out[end, 2] * (2pi) * psio # dV/d(psi)` based on the Fortran. With this fix, the differences in the `sq` spline nodes become negligible
<img width="516" height="353" alt="image" src="https://github.com/user-attachments/assets/a9fd5cab-6ee6-479f-96cd-6b7cc9151bcd" />

While the `sq.fs` nodes now appear to be all correct, if we look at the `sq.fs1` nodes, we can see there are still discrepancies - small but nonnegligible, and largest at the endpoints. Note this was documented in #45 by seeing larger errors in the `q1` profile at the axis.
<img width="663" height="349" alt="image" src="https://github.com/user-attachments/assets/37839124-e64b-4375-b801-77e73b8705f1" />
This is fixed by noticing that the boundary condition on the sq spline is not set correctly:
`sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype=4)`
which corresponds to "not-a-knot", while this spline is supposed to use the "extrap" boundary condition. If I set this line to
`sq = Spl.CubicSpline(sq_x_nodes, sq_fs_nodes; bctype="extrap")` (this is bctype = 3)
I get good agreement in the splines
<img width="657" height="345" alt="image" src="https://github.com/user-attachments/assets/b0411dec-5633-4ae6-b691-74f6bf353e2c" />
I noticed that in many places elsewhere in Equilibrium, `not-a-knot` was used where the Fortran used `extrap` (such as in `rzphi`. To avoid issues like this in the future, I also switched all (or at least most) of the spline definitions to their string representations instead of integer for clarity, since we use a dictionary mapping anyway when turning them into splines. 

With these fixes, I also checked the `rzphi` and `eqfun` outputs, and they all appeared sufficiently close for me to believe the code is bug-free. There are still some small differences in the derivatives, but I believe this will always exist since these terms are computed from a derivative of a spline of an integration, so numeric differences between Fortran and Julia can compound. I also ran this test on the DIIID ideal example, and achieved similar results, but not identical enough for me to confidently say that #45 is fully resolved, so I am going to leave the issue open. A future PR can do this process for an equilibrium file input, I want to avoid this PR getting too long.