### PR TITLE
DCON - IMPROVEMENT - deprecating ahb_flag

### DIFF
--- a/src/DCON/DconStructs.jl
+++ b/src/DCON/DconStructs.jl
@@ -187,7 +187,6 @@ end
     bin_euler::Bool = false
     euler_stride::Int = 1
     bin_vac::Bool = false # TODO: deprecated
-    ahb_flag::Bool = false # TODO: deprecated
     mthsurf0::Float64 = 1.0 # TODO: deprecated
     msol_ahb::Int = 0 # TODO: deprecated
     netcdf_out::Bool = true # TODO: might be deprecated
@@ -214,11 +213,6 @@ end
 
     # Used in Free.jl
     jmat::Vector{ComplexF64} = Vector{ComplexF64}(undef, 2 * mband + 1)
-
-    # TODO: these might be deprecated? They're used with a ahb_flag in free
-    asmat::Matrix{ComplexF64} = Matrix{ComplexF64}(undef, mpert, mpert)
-    bsmat::Matrix{ComplexF64} = Matrix{ComplexF64}(undef, mpert, mpert)
-    csmat::Matrix{ComplexF64} = Matrix{ComplexF64}(undef, mpert, mpert)
 
     parallel_threads::Int = 0
     dcon_kin_threads::Int = 0

--- a/src/DCON/Fourfit.jl
+++ b/src/DCON/Fourfit.jl
@@ -321,16 +321,6 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, ctrl::DconControl, in
     # TODO: set powers
     # Do we need this yet? Only called if power_flag = true
 
-    if ctrl.set_psilim_via_dmlim
-        # TODO: these seem to only be used for the ahb_flag, which I think is deprecated
-        ffit.asmat = reshape(Spl.spline_eval!(ffit.amats, intr.psilim), intr.mpert, intr.mpert)
-        ffit.bsmat = reshape(Spl.spline_eval!(ffit.bmats, intr.psilim), intr.mpert, intr.mpert)
-        ffit.csmat = reshape(Spl.spline_eval!(ffit.cmats, intr.psilim), intr.mpert, intr.mpert)
-        # TODO: this is used in free.f vacuum calculations, verify this is correct
-        # Should we store lower triangular factorization?
-        ffit.asmat .= cholesky(Hermitian(ffit.asmat)).L
-    end
-
     # This is used in free_run
     ffit.jmat = jmat
 

--- a/src/DCON/Free.jl
+++ b/src/DCON/Free.jl
@@ -56,12 +56,6 @@ function free_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit:
     # TODO: actually, can probably remove this function entirely and just call set_dcon_params directly
     free_write_msc(intr.psilim, ctrl, equil, intr; inmemory_op=vac_memory, ahgstr_op=ahg_file)
 
-    # TODO: there is some ahb_flag logic here that has a comment "must be false if using GPEC"
-    # I am assuming this means we don't have to implement any of it
-    # if ahb_flag
-    #     free_ahb_prep(wp, nmat, smat, asmat, bsmat, csmat, ipiva)
-    # end
-
     # Compute vacuum response matrix.
     grri = Array{Float64}(undef, 2 * (ctrl.mthvac + 5), intr.mpert * 2)
     xzpts = Array{Float64}(undef, ctrl.mthvac + 5, 4)
@@ -174,13 +168,6 @@ function free_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit:
     plasma1 = ComplexF64(real(ep[1]), 0.0)
     vacuum1 = ComplexF64(real(ev[1]), 0.0)
     total1 = ComplexF64(real(et[1]), 0.0)
-
-    # Write data for ahb and deallocate.
-    # if ahb_flag
-    #     free_ahb_write(nmat, smat, wt, et)
-    #     # Fortran did DEALLOCATE(r,z,theta,dphi,thetas,project) - we assume they are module arrays
-    #     # and will be GC'd or freed by dcon_dealloc below
-    # end
 
     if vac_memory
         VacuumMod.unset_dcon_params()


### PR DESCRIPTION
Deprecation of `ahb_flag` in relation to #65. Pretty simple fix since I never actually implemented it, basically just:
1. Removed `ahb_flag` from DCON struct
2. Removed TODOs relating to implementing `free_ahb_prep` logic
3. Removed `a/b/csmat` from DCON structs and creation logic within `Fourfit.jl`. This was kinda weird since the logic is `if sas_flag` (now `sert_psilim_via_dmlim`), but a ctrl+f of the Fortran indicates these matrices are only ever used within `free_ahb_prep` in `free.f` - perhaps there's some physics here I am missing, or perhaps whoeever added that confused the very descriptive flags named after via initials...