### PR TITLE
Some general code cleanups

### DIFF
--- a/src/DCON/DconStructs.jl
+++ b/src/DCON/DconStructs.jl
@@ -166,12 +166,9 @@ end
     bin_evals::Bool = false
     bin_euler::Bool = false
     euler_stride::Int = 1
-    bin_vac::Bool = false # TODO: deprecated
     mthsurf0::Float64 = 1.0 # TODO: deprecated
     msol_ahb::Int = 0 # TODO: deprecated
-    netcdf_out::Bool = true # TODO: might be deprecated
     out_fund::Bool = false
-    out_ahg2msc::Bool = false # TODO: deprecated
 end
 
 # TODO: how can we initialize the splines to not be nothings?

--- a/src/DCON/FixedBoundaryStability.jl
+++ b/src/DCON/FixedBoundaryStability.jl
@@ -104,19 +104,21 @@ in the Fortran code.
 """
 function compute_smallest_eigenvalue(psi::Float64, u::Array{ComplexF64,3}, sq::Spl.CubicSpline{Float64})
 
-    # Compute inverse plasma response matrix
-    # TODO: is this actually the inverse?
+    # Compute inverse plasma response matrix W = U₁ * U₂⁻¹ = adj(adj(U₂)⁻¹ * adj(U₁))
     wp_inverse = adjoint(u[:, :, 1])
     temp = adjoint(u[:, :, 2])
     wp_inverse = temp \ wp_inverse
 
-    # Symmetrize to be Hermitian
+    # Enforce that W is Hermitian
+    # TODO: Is this necessary? The DCON paper says W is Hermitian by construction.
+    # Couldn't this mask numerical issues we should be addressing directly?
+    # i.e. we should error out in the Hermitian eigenvalue solver if W is not Hermitian?
     wp_inverse .+= adjoint(wp_inverse)
     wp_inverse .*= 0.5
 
-    # Compute inverse eigenvalues, sort, and return the smallest (with a scale factor)
-    evalsi = eigvals!(Hermitian(wp_inverse))
-    indexi = sortperm(evalsi; by=abs)
+    # Compute eigenvalues, sort, and return the smallest (with a scale factor)
+    eig_vals = eigvals!(Hermitian(wp_inverse))
+    index = sortperm(eig_vals; by=abs)
     dVdpsi = Spl.spline_eval!(sq, psi)[3]
-    return evalsi[indexi[1]] * dVdpsi^2
+    return eig_vals[index[1]] * dVdpsi^2
 end

--- a/src/DCON/FixedBoundaryStability.jl
+++ b/src/DCON/FixedBoundaryStability.jl
@@ -63,7 +63,8 @@ function check_for_zero_crossings!(crit_store::Vector{Float64}, odet::OdeState, 
     # Compute smallest eigenvalue (crit) at current step
     psi = odet.psi_store[istep]
     u = odet.u_store[:, :, :, istep]
-    crit_store[istep] = compute_smallest_eigenvalue(psi, u, sq)
+    dVdpsi = Spl.spline_eval!(sq, psi)[3]
+    crit_store[istep] = compute_smallest_eigenvalue(u) * dVdpsi^2
 
     # Check for zero crossing via change in sign of crit between current and previous step
     zero_cross = false
@@ -74,7 +75,8 @@ function check_for_zero_crossings!(crit_store::Vector{Float64}, odet::OdeState, 
         fac = crit / (crit - crit_prev)
         psi_mid = psi - fac * (psi - odet.psi_store[istep - 1])
         u_mid = u .- fac .* (u .- @view(odet.u_store[:, :, :, istep - 1]))
-        crit_mid = compute_smallest_eigenvalue(psi_mid, u_mid, sq)
+        dVdpsi = Spl.spline_eval!(sq, psi_mid)[3]
+        crit_mid = compute_smallest_eigenvalue(u_mid) * dVdpsi^2
         if (crit_mid - crit) * (crit_mid - crit_prev) < 0 && abs(crit_mid) < 0.5 * min(abs(crit), abs(crit_prev))
             zero_cross = true
             println("Zero crossing detected at psi = $psi_mid, q = $q_mid")
@@ -84,41 +86,43 @@ function check_for_zero_crossings!(crit_store::Vector{Float64}, odet::OdeState, 
 end
 
 """
-    compute_smallest_eigenvalue(psi, u, sq) -> crit
+    compute_smallest_eigenvalue(u) -> crit
 
-Form the inverse plasma response matrix W⁻¹ at flux surface `psi` using the
-solution matrix `u`,and compute its eigenvalues. Return the smallest eigenvalue
-(in magnitude) scaled by dV/dψ². Performs the same function as `ode_output_get_crit`
-in the Fortran code.
+Form the inverse plasma response matrix W⁻¹ using the solution matrix `u` and
+returns its minimum eigenvalue by magnitude. Performs the same function as
+`ode_output_get_crit` in the Fortran code, except we explicitly form W⁻¹ here
+from U₁ * U₂⁻¹ using Julia's right division operator `/` instead of
+adj(adj(U₂)⁻¹ * adj(U₁)) as done in Fortran. We have also added a check to
+ensure W is Hermitian within tolerance, as the matrix should be Hermitian by
+construction but may accumulate numerical noise during integration.
 
 ### Arguments
 
-  - `psi::Float64`: The flux surface at which to evaluate
   - `u::Array{ComplexF64, 3}`: Solution matrix at `psi`
-  - `sq::Spl.CubicSpline`: Spline object containing equilibrium profiles
 
 ### Returns
 
   - `crit::Float64`: the computed scaled critical eigenvalue
 
 """
-function compute_smallest_eigenvalue(psi::Float64, u::Array{ComplexF64,3}, sq::Spl.CubicSpline{Float64})
+function compute_smallest_eigenvalue(u::Array{ComplexF64,3})
 
-    # Compute inverse plasma response matrix W⁻¹ = U₁ * U₂⁻¹ = adj(adj(U₂)⁻¹ * adj(U₁))
-    wp_inverse = adjoint(u[:, :, 1])
-    temp = adjoint(u[:, :, 2])
-    wp_inverse = temp \ wp_inverse
+    # Compute inverse plasma response matrix W⁻¹ = U₁ * U₂⁻¹
+    wp_inverse = u[:, :, 1] / u[:, :, 2]
 
+    # TODO: This section not be necessary since W should be Hermitian by construction.
+    # This likely just removes any numerical noise during integration
+    # However, if we do remove it, note that Hermitian(wp_inverse) in the eigval solve enforces Hermiticity
+    # by ignoring the lower triangle (by default, can ignore upper using `uplo=:L`), which will
+    # NOT produce identical results to taking the Hermitian part as done here unless is exactly Hermitian.
+    # Check to make sure W is at least close to Hermitian before enforcing it
+    nonherm_error = norm(0.5 * (wp_inverse - adjoint(wp_inverse))) / norm(0.5 * (wp_inverse + adjoint(wp_inverse)))
+    if nonherm_error > 1e-3
+        @warn "Computed W inverse matrix is not Hermitian within tolerance: $nonherm_error"
+    end
     # Enforce that W is Hermitian
-    # TODO: Is this necessary? The DCON paper says W is Hermitian by construction.
-    # Couldn't this mask numerical issues we should be addressing directly?
-    # i.e. we should error out in the Hermitian eigenvalue solver if W is not Hermitian?
-    wp_inverse .+= adjoint(wp_inverse)
-    wp_inverse .*= 0.5
+    hermitianpart!(wp_inverse) # Overwrites W⁻¹ with (W⁻¹ + (W⁻¹)') / 2
 
-    # Compute eigenvalues, sort, and return the smallest (with a scale factor)
-    eig_vals = eigvals!(Hermitian(wp_inverse))
-    index = sortperm(eig_vals; by=abs)
-    dVdpsi = Spl.spline_eval!(sq, psi)[3]
-    return eig_vals[index[1]] * dVdpsi^2
+    # Compute eigenvalues and return the smallest
+    return findmin(abs, eigvals!(Hermitian(wp_inverse)))[1]
 end

--- a/src/DCON/FixedBoundaryStability.jl
+++ b/src/DCON/FixedBoundaryStability.jl
@@ -104,7 +104,7 @@ in the Fortran code.
 """
 function compute_smallest_eigenvalue(psi::Float64, u::Array{ComplexF64,3}, sq::Spl.CubicSpline{Float64})
 
-    # Compute inverse plasma response matrix W = U₁ * U₂⁻¹ = adj(adj(U₂)⁻¹ * adj(U₁))
+    # Compute inverse plasma response matrix W⁻¹ = U₁ * U₂⁻¹ = adj(adj(U₂)⁻¹ * adj(U₁))
     wp_inverse = adjoint(u[:, :, 1])
     temp = adjoint(u[:, :, 2])
     wp_inverse = temp \ wp_inverse

--- a/src/DCON/Fourfit.jl
+++ b/src/DCON/Fourfit.jl
@@ -65,13 +65,9 @@ function make_metric(equil::Equilibrium.PlasmaEquilibrium; mband::Int, fft_flag:
     mpsi = length(rzphi.xs)
     mtheta = length(rzphi.ys)
 
-    println("   Equilibrium grid: $mpsi (ψ) × $mtheta (θ)")
-    println("   Fourier fit modes (mband): $mband")
-
-    metric = MetricData(mpsi, mtheta)
-
     # Set coordinate grids based on the input equilibrium
     # The `rzphi.ys` from EquilibriumAPI is normalized (0 to 1), so scale to radians.
+    metric = MetricData(mpsi, mtheta)
     metric.xs .= Vector(rzphi.xs)
     metric.ys .= Vector(rzphi.ys .* 2π)
 
@@ -177,18 +173,12 @@ and does not affect the actual matrix sizes, they are all dense.
 
 Add kinetic metric tensor components for kin_flag = true
 Set powers if necessary
-Determine if set_psilim_via_dmlim logic is needed
 """
 function make_matrix(equil::Equilibrium.PlasmaEquilibrium, ctrl::DconControl, intr::DconInternal, metric::MetricData)
 
     # --- Extract inputs ---
     sq = equil.sq
     mpsi = metric.mpsi
-
-    if ctrl.verbose
-        println("   Toroidal mode n=$(ctrl.nn), Poloidal modes m=$(intr.mlow):$(intr.mhigh) ($(intr.mpert) modes)")
-        println("   Matrix bandwidth: $(intr.mband)")
-    end
 
     # Allocations
     amats = zeros(ComplexF64, mpsi, intr.mpert, intr.mpert)
@@ -268,6 +258,8 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, ctrl::DconControl, in
                 jpert = ipert + dm
                 dmidx = dm + mid
 
+                # Note: dmat and emat here do not correspond to their representations in eq. A6 of the DCON paper,
+                # but rather to subterms that appear in the composite matrix construction in A7 and A8, respectively
                 amat[ipert, jpert] = (2π)^2 * (ctrl.nn^2 * g22[dmidx] + ctrl.nn * (m1 + m2) * g23[dmidx] + m1 * m2 * g33[dmidx])
                 bmat[ipert, jpert] = -2π * im * chi1 * (ctrl.nn * g22[dmidx] + (m1 + nq) * g23[dmidx] + m1 * q * g33[dmidx])
                 cmat[ipert, jpert] =
@@ -288,13 +280,13 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, ctrl::DconControl, in
         end
 
         # Factorize and build composites
-        # TODO: Fortran threw an error if the factorization fails for a/fmat due to small matrix bandwidth,
-        # (i.e. we cut off too many terms and matrix no longer positive definite). Should add this back in
-        # if we implement banded matrices.
+        # Note: we store the nonsingular forms F̄ and K̄ with F = QF̄Qᴴ, K = QK̄ (eq. 29 in Glasser 2016)
+        # We multiply by Q (singfac) later when performing computations later
+        # TODO: Fortran threw an error if factorization fails for A/F due to small matrix bandwidth,
+        # Add this check back in if we implement banded matrices
         amat_fact = cholesky(Hermitian(amat, :L))
         temp1 = amat_fact \ dmat
         temp2 = amat_fact \ cmat
-        # Use * for matrix multiplication (instead of .* for element-wise)
         fmat .-= adjoint(dmat) * temp1
         kmat .= emat .- (adjoint(kmat) * temp2)
         gmat .= hmat .- (adjoint(cmat) * temp2)

--- a/src/DCON/Free.jl
+++ b/src/DCON/Free.jl
@@ -1,19 +1,14 @@
 """
-    free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal, outp::DconOutput; op_netcdf_out::Bool=false)
+    free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal, outp::DconOutput)
 
 Compute the free boundary energies using VACUUM. Performs the same function as `free_run`
 in the Fortran code, except now all data is passed in memory instead of via files.
 
-### Arguments
-  - `op_netcdf_out`: Whether to write netcdf output (Bool, optional, default=false) (DEPRECATED)
-
 ### TODOs
-Remove `op_netcdf_out` argument and related logic, as netcdf output is deprecated
-Remove ahg and ahb related logic
 Check if normalize is ever false, currently always true, and if not, remove related logic
 """
 
-function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal, outp::DconOutput; op_netcdf_out::Bool=false)
+function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal, outp::DconOutput)
 
     # TODO: it looks like vac_memory is always true - remove all ahg things and just assume true?
     vac_memory = true
@@ -22,14 +17,14 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
     # Flags used within VACUUM
     complex_flag = true
     wall_flag = false
-    ahg_file = "ahg2msc_dcon.out" # Deprecated
+    ahg_file = "ahg2msc_dcon.out" # Deprecated, but needed for VACUUM function call
 
     # Allocations
     star = fill(' ', intr.mpert, intr.mpert)
-    ep = zeros(ComplexF64, intr.mpert)
-    ev = zeros(ComplexF64, intr.mpert)
-    et = zeros(ComplexF64, intr.mpert)
-    tt = zeros(ComplexF64, intr.mpert)
+    plas_eigvals = zeros(ComplexF64, intr.mpert)
+    vac_eigvals = zeros(ComplexF64, intr.mpert)
+    tot_eigvals = zeros(ComplexF64, intr.mpert)
+    temp_eigvals = zeros(ComplexF64, intr.mpert)
     wv = zeros(ComplexF64, intr.mpert, intr.mpert)
     wt = zeros(ComplexF64, intr.mpert, intr.mpert)
     wt0 = zeros(ComplexF64, intr.mpert, intr.mpert)
@@ -41,20 +36,13 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
     # Evaluate dV/dpsi at the plasma edge
     v1 = Spl.spline_eval!(equil.sq, intr.psilim)[3]
 
-    # Compute plasma response matrix.
+    # Compute plasma response matrix W = U₂ * U₁⁻¹
     if ctrl.ode_flag
-        temp .= adjoint(odet.u[:, 1:intr.mpert, 1])
-        wp .= adjoint(odet.u[:, 1:intr.mpert, 2])
-        # Compute wp using LU decomposition
-        temp_fact = lu(temp)
-        wp .= temp_fact \ wp
-        wp .= adjoint(wp) / equil.psio^2
+        @views wp = (odet.u[:, :, 2] / odet.u[:, :, 1]) ./ equil.psio^2
     end
 
-    # Write file for mscvac
-    # TODO: can likely remove last two arguments, ahgstr_op is deprecated
-    # TODO: actually, can probably remove this function entirely and just call set_dcon_params directly
-    free_write_msc(intr.psilim, ctrl, equil, intr; inmemory_op=vac_memory, ahgstr_op=ahg_file)
+    # Set VACUUM run parameters and boundary shape
+    set_vacuum_inputs(intr.psilim, ctrl, equil, intr)
 
     # Compute vacuum response matrix.
     grri = Array{Float64}(undef, 2 * (ctrl.mthvac + 5), intr.mpert * 2)
@@ -66,19 +54,11 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
     VacuumMod.mscvac(wv, intr.mpert, equil.config.control.mtheta, ctrl.mthvac, complex_flag, kernelsignin,
         wall_flag, farwal_flag, grri, xzpts, ahg_file, intr.dir_path)
 
-    # TODO: assuming bin_vac is deprecated for good, will remove all calls later after checking
-    # if bin_vac
-    #     @warn "!! WARNING: Use of vacuum.bin is deprecated in GPEC. Set bin_vac = false in dcon.in to reduce file IO."
-    #     bin_open(vac_unit, "vacuum.bin", "UNKNOWN", "REWIND", "none")
-    #     write(vac_unit, grri)
-    # end
 
     kernelsignin = 1.0
     VacuumMod.mscvac(wv, intr.mpert, equil.config.control.mtheta, ctrl.mthvac, complex_flag, kernelsignin,
         wall_flag, farwal_flag, grri, xzpts, ahg_file, intr.dir_path)
-    # if bin_vac
-    #     write(vac_unit, grri)
-    # end
+
     if ctrl.wv_farwall_flag
         temp .= wv
     end
@@ -87,48 +67,33 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
     kernelsignin = -1.0
     VacuumMod.mscvac(wv, intr.mpert, equil.config.control.mtheta, ctrl.mthvac, complex_flag, kernelsignin,
         wall_flag, farwal_flag, grri, xzpts, ahg_file, intr.dir_path)
-    # if bin_vac
-    #     write(vac_unit, grri)
-    # end
 
     kernelsignin = 1.0
     VacuumMod.mscvac(wv, intr.mpert, equil.config.control.mtheta, ctrl.mthvac, complex_flag, kernelsignin,
         wall_flag, farwal_flag, grri, xzpts, ahg_file, intr.dir_path)
-    # if bin_vac
-    #     write(vac_unit, grri)
-    #     write(vac_unit, xzpts)
-    #     bin_close(vac_unit)
-    # end
 
     if ctrl.wv_farwall_flag
         wv .= temp
     end
 
     # Scale vacuum matrix by singfac = (m - nn*qlim)
-    singfac = (intr.mlow .- ctrl.nn .* intr.qlim) .+ collect(0:intr.mpert-1)
+    singfac = collect(intr.mlow:intr.mhigh) .- ctrl.nn .* intr.qlim
     for ipert in 1:intr.mpert
         wv[ipert, :] .*= singfac[ipert]
         wv[:, ipert] .*= singfac[ipert]
     end
 
-    # Compute complex energy eigenvalues
+    # Compute complex energy eigenvalues and vectors
     wt .= wp .+ wv
     wt0 .= wt
-
-    # use Eigen decomposition for general complex matrix (get left & right eigenvectors)
-    # For general complex: use eigen(wt) which returns eigenvalues and eigenvectors (right)
-    # For left eigenvectors we can compute eigen(wt') and conj-transpose as needed,
-    # but Fortran uses zgeev('V','V',...) returning both vl and vr.
-    Ev = eigen(wt)  # Ev.values, Ev.vectors (columns are eigenvectors)
-    # Ev.vectors are right eigenvectors; we need to reorder by magnitude using bubble on real parts of eigenvalues
-    et .= Ev.values
-    eindex = sortperm(real.(et); rev=true)
-
-    tt .= et
-    # rearrange wt columns to correspond to eigenvector reordering similar to Fortran
+    Ev = eigen(wt)
+    tot_eigvals .= Ev.values
+    eindex = sortperm(real.(tot_eigvals); rev=true)
+    temp_eigvals .= tot_eigvals
+    # Rearrange wt columns to correspond to eigenvector reordering similar to Fortran
     for ipert in 1:intr.mpert
         wt[:, ipert] .= Ev.vectors[:, eindex[intr.mpert+1-ipert]]
-        et[ipert] = tt[eindex[intr.mpert+1-ipert]]
+        tot_eigvals[ipert] = temp_eigvals[eindex[intr.mpert+1-ipert]]
     end
 
     # Normalize eigenfunction and energy.
@@ -140,7 +105,7 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
             end
             norm /= v1
             wt[:, isol] ./= sqrt(norm)
-            et[isol] /= norm
+            tot_eigvals[isol] /= norm
         end
     end
 
@@ -161,13 +126,13 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
     wvt .= adjoint(wt) * (wv * wt)
 
     for ipert in 1:intr.mpert
-        ep[ipert] = wpt[ipert, ipert]
-        ev[ipert] = wvt[ipert, ipert]
+        plas_eigvals[ipert] = wpt[ipert, ipert]
+        vac_eigvals[ipert] = wvt[ipert, ipert]
     end
 
-    plasma1 = ComplexF64(real(ep[1]), 0.0)
-    vacuum1 = ComplexF64(real(ev[1]), 0.0)
-    total1 = ComplexF64(real(et[1]), 0.0)
+    plasma1 = ComplexF64(real(plas_eigvals[1]), 0.0)
+    vacuum1 = ComplexF64(real(vac_eigvals[1]), 0.0)
+    total1 = ComplexF64(real(tot_eigvals[1]), 0.0)
 
     if vac_memory
         VacuumMod.unset_dcon_params()
@@ -188,9 +153,9 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
         h5open(joinpath(intr.dir_path, outp.fname_euler_h5), "r+") do euler_h5
             euler_h5["vacuum/wt"] = wt
             euler_h5["vacuum/wt0"] = wt0
-            euler_h5["vacuum/ep"] = ep
-            euler_h5["vacuum/ev"] = ev
-            euler_h5["vacuum/et"] = et
+            euler_h5["vacuum/ep"] = plas_eigvals
+            euler_h5["vacuum/ev"] = vac_eigvals
+            euler_h5["vacuum/et"] = tot_eigvals
             euler_h5["vacuum/wv_farwall_flag"] = ctrl.wv_farwall_flag
             euler_h5["integration/xi_psi"] = odet.u_store[:, :, 1, :]
             euler_h5["integration/u2"] = odet.u_store[:, :, 2, :] # TODO: what to name this? These are the "conjugate momenta" of u1
@@ -201,8 +166,8 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
 
     # Write to screen and copy to output.
     if ctrl.verbose
-        println("Energies: plasma = ", real(ep[1]), ", vacuum = ", real(ev[1]),
-            ", real = ", real(et[1]), ", imaginary = ", imag(et[1]))
+        println("Energies: plasma = ", real(plas_eigvals[1]), ", vacuum = ", real(vac_eigvals[1]),
+            ", real = ", real(tot_eigvals[1]), ", imaginary = ", imag(tot_eigvals[1]))
     end
 
     if outp.write_dcon_out
@@ -211,7 +176,7 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
         write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
         for isol in 1:intr.mpert
             write_output(outp, :dcon_out, @sprintf("%6d %11.3e %11.3e %11.3e %11.3e",
-                isol, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
+                isol, real(plas_eigvals[isol]), real(vac_eigvals[isol]), real(tot_eigvals[isol]), imag(tot_eigvals[isol])))
         end
         write_output(outp, :dcon_out, "\n   isol   plasma      vacuum   re total   im total\n")
 
@@ -221,7 +186,7 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
         for isol in 1:intr.mpert
             write_output(outp, :dcon_out, "\n   isol   imax   plasma      vacuum   re total   im total\n")
             write_output(outp, :dcon_out, @sprintf("%6d %6d %11.3e %11.3e %11.3e %11.3e",
-                isol, imax, real(ep[isol]), real(ev[isol]), real(et[isol]), imag(et[isol])))
+                isol, imax, real(plas_eigvals[isol]), real(vac_eigvals[isol]), real(tot_eigvals[isol]), imag(tot_eigvals[isol])))
             write_output(outp, :dcon_out, "\n  ipert     m      re wt      im wt      abs wt\n")
             for ipert in 1:intr.mpert
                 write_output(outp, :dcon_out,
@@ -244,32 +209,11 @@ function free_run!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaE
         end
     end
 
-    # Compute separate plasma and vacuum eigenvalues.
-    # Right eigenvalues/vectors of wp
-    Ev_wp = eigen(wp)
-    ep .= Ev_wp.values
-    eindex = sortperm(real.(ep); rev=true)
-    tt .= ep
-    for ipert in 1:intr.mpert
-        wp[:, ipert] .= Ev_wp.vectors[:, eindex[intr.mpert+1-ipert]]
-        ep[ipert] = tt[eindex[intr.mpert+1-ipert]]
-    end
-    # For vacuum (Hermitian) use eigen of Hermitian wv
-    Ev_wv = eigen(Hermitian(wv, :U))
-    ev .= Ev_wv.values
-
-    # Optionally write netcdf file
-    # TODO: move this to HDF5 or something else later, make it an input flag?
-    # if op_netcdf_out
-    #     dcon_netcdf_out(wp, wv, wt, wt0, ep, ev, et)
-    # end
-
     return plasma1, vacuum1, total1
 end
 
 """
-    free_write_msc(psifac::Float64, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, intr::DconInternal; inmemory_op::Union{Bool,Nothing}=nothing,
-    ahgstr_op::Union{String,Nothing}=nothing)
+    set_vacuum_inputs(psifac::Float64, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, intr::DconInternal)
 
 Prepare and write the necessary parameters and boundary shape to VACUUM for computing the vacuum response matrix.
 Performs the same function as `free_write_msc` in the Fortran code, except we will always use in-memory communication.
@@ -280,20 +224,9 @@ Performs the same function as `free_write_msc` in the Fortran code, except we wi
   - `ctrl`: DCON control parameters (DconControl)
   - `equil`: Plasma equilibrium data (Equilibrium.PlasmaEquilibrium)
   - `intr`: Internal DCON parameters (DconInternal)
-  - `inmemory_op`: Whether to use in-memory communication with VACUUM (Bool, optional, default=false)
-  - `ahgstr_op`: Communication file name if not using in-memory (String, optional, default="ahg2msc_dcon.out")
 
-### TODOs
-
-Remove `inmemory_op` and `ahgstr_op` arguments and related logic, always use in-memory communication
 """
-function free_write_msc(psifac::Float64, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, intr::DconInternal; inmemory_op::Union{Bool,Nothing}=nothing,
-    ahgstr_op::Union{String,Nothing}=nothing)
-
-    # Defaults for optional arguments
-    inmemory = isnothing(inmemory_op) ? false : inmemory_op
-    ahgstr = isnothing(ahgstr_op) ? "ahg2msc_dcon.out" : ahgstr_op
-    inmemory = true # TODO: remove the above, and modify the code logic so VACUUM is always in memory
+function set_vacuum_inputs(psifac::Float64, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, intr::DconInternal)
 
     # Allocations
     theta_norm = Vector(equil.rzphi.ys)
@@ -324,12 +257,8 @@ function free_write_msc(psifac::Float64, ctrl::DconControl, equil::Equilibrium.P
     end
 
     # Pass all required values to VACUUM
-    if inmemory
-        VacuumMod.set_dcon_params(equil.config.control.mtheta, intr.mlow, intr.mhigh, n, qa,
-            reverse(r), reverse(z), reverse(delta))
-    else
-        # TODO: this section contains ahg2msc file writing, which is deprecated, just remove
-    end
+    VacuumMod.set_dcon_params(equil.config.control.mtheta, intr.mlow, intr.mhigh, n, qa,
+        reverse(r), reverse(z), reverse(delta))
 end
 
 """
@@ -359,22 +288,22 @@ function free_compute_wv_spline(ctrl::DconControl, equil::Equilibrium.PlasmaEqui
 
         # Newton iteration to find psi at qi
         psii = ctrl.psiedge + (intr.psilim - ctrl.psiedge) * ((i - 1) / npsi)
-        it = 0
+        converged = false
         for _ in 1:itmax
             dpsi = (qi - qval(psii)) / q1val(psii)
             psii += dpsi
-            it += 1
-            abs(dpsi) < eps * abs(psii) && break
+            if abs(dpsi) < eps * abs(psii)
+                converged = true
+                psi_array[i] = psii
+                break
+            end
         end
-
-        if it == itmax
-            error("Can't find psilim after $itmax iterations.")
-        else
-            psi_array[i] = psii
+        if !converged
+            error("Newton iteration for psilim did not converge after $itmax iterations.")
         end
 
         # Prepare vacuum matrices
-        free_write_msc(psii, ctrl, equil, intr; inmemory_op=true, ahgstr_op="")
+        set_vacuum_inputs(psii, ctrl, equil, intr)
         grri = Array{Float64}(undef, 2 * (ctrl.mthvac + 5), intr.mpert * 2)
         xzpts = Array{Float64}(undef, ctrl.mthvac + 5, 4)
         wv = zeros(ComplexF64, intr.mpert, intr.mpert)
@@ -389,7 +318,7 @@ function free_compute_wv_spline(ctrl::DconControl, equil::Equilibrium.PlasmaEqui
             wall_flag, farwal_flag, grri, xzpts, ahg_file, intr.dir_path)
 
         # Apply singular factor scaling
-        singfac = intr.mlow .- ctrl.nn * qi .+ collect(0:intr.mpert-1)
+        singfac = collect(intr.mlow:intr.mhigh) .- ctrl.nn * qi
         for ipert in 1:intr.mpert
             wv[ipert, :] .*= singfac[ipert]
             wv[:, ipert] .*= singfac[ipert]
@@ -420,7 +349,7 @@ function free_compute_total(equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitV
 
     wp = zeros(ComplexF64, intr.mpert, intr.mpert)
     temp = zeros(ComplexF64, intr.mpert, intr.mpert)
-    et = zeros(ComplexF64, intr.mpert)
+    tot_eigvals = zeros(ComplexF64, intr.mpert)
     wt = zeros(ComplexF64, intr.mpert, intr.mpert)
 
     v1 = Spl.spline_eval!(equil.sq, intr.psilim)[3]
@@ -442,7 +371,7 @@ function free_compute_total(equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitV
     eindex = sortperm(real.(Ev.values); rev=true)
     for ipert in 1:intr.mpert
         wt[:, ipert] .= Ev.vectors[:, eindex[intr.mpert+1-ipert]]
-        et[ipert] = Ev.values[eindex[intr.mpert+1-ipert]]
+        tot_eigvals[ipert] = Ev.values[eindex[intr.mpert+1-ipert]]
     end
 
     # Normalize eigenfunction and energy (only need the first eigenmode)
@@ -453,8 +382,8 @@ function free_compute_total(equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitV
             norm += ffit.jmat[jpert-ipert+intr.mband+1] * wt[ipert, isol] * conj(wt[jpert, isol])
         end
         norm /= v1
-        et[isol] /= norm
+        tot_eigvals[isol] /= norm
     end
 
-    return et[1]
+    return tot_eigvals[1]
 end

--- a/src/DCON/Main.jl
+++ b/src/DCON/Main.jl
@@ -1,4 +1,4 @@
-function Main(path::String)
+function Main(path::String="./")
 
     println("DCON START")
     println("----------------------------------")
@@ -91,6 +91,9 @@ function Main(path::String)
     sing_find!(intr, ctrl, equil)
 
     # Determine poloidal mode numbers
+    if ctrl.delta_mlow < 0 || ctrl.delta_mhigh < 0
+        error("Negative delta_mlow or delta_mhigh not allowed")
+    end
     if ctrl.cyl_flag
         intr.mlow = ctrl.delta_mlow
         intr.mhigh = ctrl.delta_mhigh
@@ -116,11 +119,11 @@ function Main(path::String)
     # Fit equilibrium quantities to Fourier-spline functions.
     if ctrl.mat_flag || ctrl.ode_flag
         if ctrl.verbose
-            println("     q0 = $(equil.params.q0), qmin = $(equil.params.qmin), qmax = $(equil.params.qmax), q95 = $(equil.params.q95)")
-            println("     set_psilim_via_dmlim = $(ctrl.set_psilim_via_dmlim), dmlim = $(ctrl.dmlim), qlim = $(intr.qlim), psilim = $(intr.psilim)")
-            println("     betat = $(equil.params.betat), betan = $(equil.params.betan), betap1 = $(equil.params.betap1)")
-            println("     nn = $(ctrl.nn), mlow = $(intr.mlow), mhigh = $(intr.mhigh), mpert = $(intr.mpert), mband = $(intr.mband)")
-            println(" Fourier analysis of metric tensor components")
+            println("Run parameters:")
+            println("   q0 = $(equil.params.q0), qmin = $(equil.params.qmin), qmax = $(equil.params.qmax), q95 = $(equil.params.q95)")
+            println("   set_psilim_via_dmlim = $(ctrl.set_psilim_via_dmlim), dmlim = $(ctrl.dmlim), qlim = $(intr.qlim), psilim = $(intr.psilim)")
+            println("   betat = $(equil.params.betat), betan = $(equil.params.betan), betap1 = $(equil.params.betap1)")
+            println("   nn = $(ctrl.nn), mlow = $(intr.mlow), mhigh = $(intr.mhigh), mpert = $(intr.mpert), mband = $(intr.mband)")
         end
 
         if outp.write_dcon_out
@@ -169,7 +172,7 @@ function Main(path::String)
         if ctrl.verbose
             println("Computing free boundary energies")
         end
-        plasma1, vacuum1, total1 = free_run!(odet, ctrl, equil, ffit, intr, outp; op_netcdf_out=false) # outp.netcdf_out)
+        plasma1, vacuum1, total1 = free_run!(odet, ctrl, equil, ffit, intr, outp)
     end
 
     # Output results of fixed-boundary stability calculations

--- a/src/DCON/Mercier.jl
+++ b/src/DCON/Mercier.jl
@@ -55,7 +55,7 @@ function mercier_scan!(locstab_fs::Matrix{Float64}, plasma_eq::Equilibrium.Plasm
             @views ff_fs[itheta, :] .*= jac / v1
         end
 
-        ff = Spl.CubicSpline(Vector(rzphi.ys), ff_fs; bctype=2) # bctype=2 is periodic
+        ff = Spl.CubicSpline(Vector(rzphi.ys), ff_fs; bctype="periodic")
 
         # Integrate quantities with respect to theta
         Spl.spline_integrate!(ff)

--- a/src/DCON/Ode.jl
+++ b/src/DCON/Ode.jl
@@ -31,7 +31,6 @@ including solution vectors, tolerances, and flags for the integration process.
     u::Array{ComplexF64,3} = zeros(ComplexF64, mpert, mpert, 2)            # solution vectors
     ud::Array{ComplexF64,3} = zeros(ComplexF64, mpert, mpert, 2)           # derivative of solution vectors used in GPEC
     ising::Int = 0               # index of next singular surface
-    m1::Int = 0                 # poloidal mode number for the next singular surface (?)
     psimax::Float64 = 0.0         # maximum psi value for the integrator
     singfac::Float64 = 0.0      # separation from singular surface in terms of m - nq
     next::String = ""           # next integration action ("cross" or "finish")
@@ -107,6 +106,10 @@ function ode_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::
 
     # If at a rational surface, do the appropriate crossing routine, then integrate again
     while odet.ising != ctrl.ksing && odet.next == "cross"
+        if ctrl.verbose
+            println("   ψ = $(intr.sing[odet.ising].psifac), q = $(intr.sing[odet.ising].q)")
+        end
+
         if ctrl.kin_flag
             error("kin_flag = true not implemented yet!")
         else
@@ -120,7 +123,6 @@ function ode_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::
     if ctrl.psiedge < intr.psilim
         # Find the peak dW in the edge region and truncate integration data there
         odet.step = findmax_dW_edge!(odet, ctrl, equil, ffit, intr)
-        println("max dw = $(odet.dW_edge[odet.step]) at ψ = $(odet.psi_store[odet.step])")
         trim_storage!(odet)
         if ctrl.verbose
             println("Truncating integration at peak edge dW: ψ = $(odet.psi_store[odet.step]), q = $(odet.q_store[odet.step])")
@@ -143,7 +145,7 @@ function ode_run(ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::
 
     if outp.write_euler_h5
         if ctrl.verbose
-            println("Writing saved integration data to euler.h5")
+            println("Writing saved integration data to $(outp.fname_euler_h5)")
         end
         write_euler_h5(ctrl, equil, intr, odet, outp)
     end
@@ -155,7 +157,7 @@ end
     ode_axis_init!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, intr::DconInternal)
 
 Initialize the OdeState struct for the case of sing_start = 0 (axis initialization). This includes
-determining `psifac`, `psimax`, `ising`, `m1`, `singfac`, and initializing `u`.
+determining `psifac`, `psimax`, `ising`, `singfac`, and initializing `u`.
 
 ### TODOs
 
@@ -173,25 +175,25 @@ function ode_axis_init!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.Pl
 
     # Use Newton iteration to find starting psi if qlow is above q0
     if ctrl.qlow > equil.sq.fs[1, 4]
-        # Start check from the edge for robustness in reverse shear cores
-        for jpsi in equil.sq.mx:-1:2  # avoid starting iteration on endpoints
-            if equil.sq.fs[jpsi-1, 4] < ctrl.qlow
-                odet.psifac = equil.sq.xs[jpsi]
-                break
-            end
+        # Find last index where q < qlow 
+        idx = findlast(jpsi -> equil.sq.fs[jpsi-1, 4] < ctrl.qlow, 2:equil.sq.mx)
+        if idx !== nothing
+            odet.psifac = equil.sq.xs[idx]
         end
-        it = 0
-        while it ≤ itmax
+        # Refine psifac using Newton iteration
+        converged = false
+        for _ in 1:itmax
             it += 1
             dpsi = (ctrl.qlow - qval(odet.psifac)) / q1val(odet.psifac)
             odet.psifac += dpsi
-            if abs(dpsi) < eps * abs(odet.psifac)
-                break
-            end
+            abs(dpsi) < eps * abs(odet.psifac) && (converged = true; break)
+        end
+        if !converged
+            error("Newton iteration for psifac did not converge after $itmax iterations.")
         end
     end
 
-    # Find inner singular surface
+    # Find inner singular surface (where sing.psifac > psi(qlow/q0))
     if false #(TODO: kin_flag)
     # for ising = 1:kmsing
     #     if kinsing[ising].psifac > psifac
@@ -199,41 +201,15 @@ function ode_axis_init!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.Pl
     #     end
     # end
     else
-        odet.ising = 0
-        for i in 1:intr.msing
-            if intr.sing[i].psifac > odet.psifac
-                odet.ising = max(0, i - 1)
-                break
-            end
-        end
+        odet.ising = searchsortedfirst(getfield.(intr.sing, :psifac), odet.psifac) - 1  
     end
 
     # Find next singular surface
-    if false # TODO: (kin_flag)
-    # while true
-    #     ising += 1
-    #     if ising > kmsing
-    #         break
-    #     end
-    #     if psilim < kinsing[ising].psifac
-    #         break
-    #     end
-    #     odet.q = kinsing[ising].q
-    #     if mlow <= nn * odet.q && mhigh >= nn * odet.q
-    #         break
-    #     end
-    # end
-    # if ising > kmsing || singfac_min == 0
-    #     psimax = psilim * (1 - eps)
-    #     next = "finish"
-    # elseif psilim < kinsing[ising].psifac
-    #     psimax = psilim * (1 - eps)
-    #     next = "finish"
-    # else
-    #     psimax = kinsing[ising].psifac - singfac_min / abs(nn * kinsing[ising].q1)
-    #     next = "cross"
-    # end
+    if false
+        # TODO: (kin_flag)
     else
+        # Find next singular surface (either next one in the list or outside integration limits)
+        # TODO: clean this up in integration bounds PR, this exact block appears several times
         while true
             odet.ising += 1
             if odet.ising > intr.msing || intr.psilim < intr.sing[min(odet.ising, intr.msing)].psifac
@@ -243,6 +219,7 @@ function ode_axis_init!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.Pl
                 break
             end
         end
+        # Determine psimax and classify next integration limit type
         if odet.ising > intr.msing || intr.psilim < intr.sing[min(odet.ising, intr.msing)].psifac || ctrl.singfac_min == 0
             odet.psimax = intr.psilim * (1 - eps)
             odet.next = "finish"
@@ -256,87 +233,12 @@ function ode_axis_init!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.Pl
     for ipert in 1:intr.mpert
         odet.u[ipert, ipert, 2] = 1
     end
-
-    # Compute conditions at next singular surface
-    if false #TODO: (kin_flag)
-    # if kmsing > 0
-    #     m1 = round(Int, nn * kinsing[ising].q)
-    # else
-    #     m1 = round(Int, nn * qlim) + sign(one, nn * sq.fs1[mpsi, 5])
-    # end
-    else
-        # note: Julia's default round does Banker's rounding, to match NINT in fortran we need to specify RoundFromZero
-        if intr.msing > 0
-            odet.m1 = round(Int, ctrl.nn * intr.sing[odet.ising].q, RoundFromZero)
-        else
-            odet.m1 = round(Int, ctrl.nn * intr.qlim, RoundFromZero) + sign(ctrl.nn * equil.sq.fs1[end, 4])
-        end
-    end
-    odet.singfac = abs(odet.m1 - ctrl.nn * equil.sq.fs[1, 4]) # Fortran: q=sq%fs(0,4)
 end
 
 # TODO: NOT IMPLEMENTED YET! (low priority, just make sure sing_start = 0 in dcon.toml)
 function ode_sing_init()
     return
 end
-#     # Declare and initialize local variables
-#     star = fill(' ', mpert)
-#     # local variables
-#     ua = Array{Complex{r8}}(undef, mpert, 2*mpert, 2)
-#     dpsi = 0.0
-#     new = true
-
-#     ising = sing_start
-#     dpsi = singfac_min/abs(nn*sing[ising].q1)*10
-#     odet.psifac = sing[ising].psifac + dpsi
-#     odet.q = sing[ising].q + dpsi*sing[ising].q1
-
-#     # Allocate and initialize solution arrays
-#     u      = zeros(Complex{r8}, mpert, mpert, 2)
-#     du     = zeros(Complex{r8}, mpert, mpert, 2)
-#     unorm0 = zeros(r8, 2*mpert)
-#     unorm  = zeros(r8, 2*mpert)
-#     index  = zeros(Int, 2*mpert)
-
-#     if old_init
-#         u .= 0.0
-#         for ipert ∈ 1:mpert
-#             u[ipert, ipert, 2] = 1.0
-#         end
-#     else
-#         sing_get_ua(ising, odet.psifac, ua)
-#         # Big slice: u = ua[:, mpert+1:2*mpert,:]
-#         for i = 1:mpert, j = 1:mpert, k = 1:2
-#             u[i, j, k] = ua[i, mpert+j, k]
-#         end
-#     end
-#     msol = mpert
-#     neq = 4 * mpert * msol
-
-#     # Compute conditions at next singular surface
-#     while true
-#         ising += 1
-#         if ising > msing || psilim < sing[ising ≤ msing ? ising : msing].psifac
-#             break
-#         end
-#         odet.q = sing[ising].q
-#         if mlow ≤ nn*q && mhigh ≥ nn*q
-#             break
-#         end
-#     end
-# This needs to be fixed up
-#     if ising > msing || psilim < sing[ising ≤ msing ? ising : msing].psifac
-#         m1 = round(Int, ctrl.nn*intr.qlim) + round(Int, sign(one, ctrl.nn*equil.sq.fs1[mpsi, 4]))
-#         psimax = psilim * (1-eps)
-#         next_ = "finish"
-#     else
-#         m1 = round(Int, nn*sing[ising].q)
-#         psimax = sing[ising].psifac - singfac_min/abs(nn*sing[ising].q1)
-#         next_ = "cross"
-#     end
-#     # Terminate, or in Julia just return (no need for RETURN)
-#     return nothing  # or could return a struct with all these values, for a more Julian approach
-# end
 
 """
     ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal)
@@ -354,27 +256,23 @@ Remove while true logic
 function ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::DconInternal)
 
     # Fixup solution at singular surface
-    if ctrl.verbose
-        println("   ψ = $(intr.sing[odet.ising].psifac), q = $(intr.sing[odet.ising].q)")
-    end
     ode_unorm!(odet.u, odet, ctrl, intr, true)
 
     # Get asymptotic coefficients before crossing rational surface
-    ca = sing_get_ca(ctrl, intr, odet)
-    odet.ca_l[:, :, :, odet.ising] .= ca
+    odet.ca_l[:, :, :, odet.ising] .= sing_get_ca(ctrl, intr, odet)
 
     # Re-initialize on opposite side of rational surface
     psi_old = odet.psifac
     singp = intr.sing[odet.ising]
     ipert0 = round(Int, ctrl.nn * singp.q, RoundFromZero) - intr.mlow + 1
     dpsi = singp.psifac - odet.psifac
-    odet.psifac = singp.psifac + dpsi
+    odet.psifac += 2 * dpsi # jump to other side of singular surface
     ua = sing_get_ua(ctrl, intr, odet)
     if !ctrl.con_flag
         odet.u[:, odet.index[1, odet.ifix], :] .= 0
     end
 
-    # Update solution vectors
+    # Approximate solution vectors across singular surface
     du1 = zeros(ComplexF64, intr.mpert, intr.mpert, 2)
     du2 = zeros(ComplexF64, intr.mpert, intr.mpert, 2)
     params = (ctrl, equil, ffit, intr, odet)
@@ -382,15 +280,16 @@ function ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.
     sing_der!(du2, odet.u, params, odet.psifac)
     odet.u .+= (du1 .+ du2) .* dpsi
     if !ctrl.con_flag
+        # Zero out the resonant components
         odet.u[ipert0, :, :] .= 0
+        # Introduce the small asymptotic resonant solution on the other side of the singular surface
         odet.u[:, odet.index[1, odet.ifix], :] .= ua[:, ipert0+intr.mpert, :]
     end
 
     # Get asymptotic coefficients after crossing rational surface
-    ca = sing_get_ca(ctrl, intr, odet)
-    odet.ca_r[:, :, :, odet.ising] .= ca
+    odet.ca_r[:, :, :, odet.ising] .= sing_get_ca(ctrl, intr, odet)
 
-    # Find next ising
+    # Find next singular surface (either the next in the list or outside integration limits)
     while true
         odet.ising += 1
         if odet.ising > intr.msing || intr.psilim < intr.sing[min(odet.ising, intr.msing)].psifac
@@ -401,23 +300,21 @@ function ode_ideal_cross!(odet::OdeState, ctrl::DconControl, equil::Equilibrium.
         end
     end
 
-    # Compute conditions at next singular surface
+    # Determine psimax and classify next integration limit type
     if odet.ising > intr.msing || intr.psilim < intr.sing[min(odet.ising, intr.msing)].psifac
         odet.psimax = intr.psilim * (1 - eps)
-        odet.m1 = round(Int, ctrl.nn * intr.qlim, RoundFromZero) + sign(ctrl.nn * equil.sq.fs1[end, 4])
         odet.next = "finish"
     else
         singp = intr.sing[odet.ising] # Update singp
         odet.psimax = singp.psifac - ctrl.singfac_min / abs(ctrl.nn * singp.q1)
-        odet.m1 = round(Int, ctrl.nn * singp.q, RoundFromZero)
     end
 
-    # Restart ode solver
-    odet.new = true
-    odet.psi_store[odet.step] = odet.psifac # Store current psi
-    odet.q_store[odet.step] = odet.q # Store current q
-    odet.u_store[:, :, :, odet.step] = odet.u   # Store current u
-    odet.step += 1 # Advance step to account for crossing step
+    # Store values after crossing step and advance
+    odet.psi_store[odet.step] = odet.psifac
+    odet.q_store[odet.step] = odet.q
+    odet.u_store[:, :, :, odet.step] = odet.u
+    odet.ud_store[:, :, :, odet.step] = odet.ud
+    odet.step += 1
 end
 
 # Example stub for kinetic crossing
@@ -475,7 +372,7 @@ and `ode_record_edge` post-integration using the saved data.
 """
 function integrator_callback!(integrator)
     
-    ctrl, equil, ffit, intr, odet = integrator.p
+    ctrl, _, _, intr, odet = integrator.p
 
     # Update integration tolerances
     integrator.opts.reltol = compute_tols(ctrl, intr, odet)
@@ -719,6 +616,7 @@ function transform_u!(odet::OdeState, intr::DconInternal)
             # Matrix multiplication gauss = gauss * temp
             gauss[:, :, ifix] .= gauss[:, :, ifix] * temp
         end
+        # Account for zeroed indices at singular surfaces in `ode_ideal_cross`
         if odet.sing_flag[ifix]
             gauss[:, odet.index[1, ifix], ifix] .= 0.0
         end

--- a/src/DCON/Sing.jl
+++ b/src/DCON/Sing.jl
@@ -43,21 +43,16 @@ function sing_find!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
             psifac = (psi0 + psi1) / 2 # initial guess for bisection
 
             # Bisection method to find singular surface
-            while it < itmax
-                it += 1
+            converged = false
+            for _ in 1:itmax
                 psifac = (psi0 + psi1) / 2
-                singfac = (m - ctrl.nn * Spl.spline_eval!(equil.sq, psifac)[4]) * dm
-                if abs(singfac) <= 1e-8
-                    break
-                elseif singfac > 0
-                    psi0 = psifac
-                else
-                    psi1 = psifac
-                end
+                singfac = (m - n * Spl.spline_eval!(equil.sq, psifac)[4]) * dm
+                abs(singfac) < 1e-8 && (converged = true; break)
+                singfac > 0 ? (psi0 = psifac) : (psi1 = psifac)
             end
 
-            if it == itmax
-                error("Bisection did not converge for m = $m")
+            if !converged
+                error("Bisection did not converge for m = $m after $itmax iterations.")
             else
                 push!(intr.sing, SingType(;
                     m=m,
@@ -122,15 +117,19 @@ function sing_lim!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pla
         q1val(ψ) = Spl.spline_deriv1!(equil.sq, ψ)[2][4]
 
         intr.psilim = equil.sq.xs[jpsi]
+        converged = false
         for _ in 1:itmax
             dpsi = (intr.qlim - qval(intr.psilim)) / q1val(intr.psilim)
             intr.psilim += dpsi
-            abs(dpsi) < eps * abs(intr.psilim) && return intr.q1lim = q1val(intr.psilim)
+            if abs(dpsi) < eps * abs(intr.psilim)
+                converged = true
+                intr.q1lim = q1val(intr.psilim)
+                break
+            end
         end
-        error("Can't find psilim after $itmax iterations.")
-    else
-        # Just use the equilibrium values for psilim, qlim, and q1lim
-        return
+        if !converged
+            error("Can't find psilim after $itmax iterations.")
+        end
     end
 end
 
@@ -168,7 +167,9 @@ function sing_vmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         return
     end
 
-    # Compute ranges
+    # Compute the resonant (r) and nonresonant (n) indices of the shearing transformation matrix R
+    # 1 indexes along the N*M dimension, and 2 along the 2*N*M dimension
+    # In 2D, see eq. 41 of 2016 Glasser DCON paper
     singp.r1 = [ipert0]
     singp.r2 = [ipert0, ipert0 + intr.mpert]
     singp.n1 = [i for i in 1:intr.mpert if i != ipert0]
@@ -189,6 +190,8 @@ function sing_vmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
     di = singp.m0mat[1, 1] * singp.m0mat[2, 2] - singp.m0mat[2, 1] * singp.m0mat[1, 2]
     singp.di = real(di)
     singp.alpha = sqrt(-complex(singp.di))
+
+    # This is the parameter α but for all modes - α = 0 for non-resonant modes
     singp.power[ipert0] = -singp.alpha
     singp.power[ipert0+intr.mpert] = singp.alpha
 
@@ -203,7 +206,7 @@ function sing_vmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         singp.vmat[ipert, ipert+intr.mpert, 2, 1] = 1
     end
 
-    # Zeroth-order resonant solutions
+    # Zeroth-order resonant solutions - solve (M₀ - αI)v₀ = 0
     singp.vmat[ipert0, ipert0, 1, 1] = 1
     singp.vmat[ipert0, ipert0+intr.mpert, 1, 1] = 1
     singp.vmat[ipert0, ipert0, 2, 1] = -(singp.m0mat[1, 1] + singp.alpha) / singp.m0mat[1, 2]
@@ -213,7 +216,7 @@ function sing_vmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         conj(singp.vmat[ipert0, ipert0+intr.mpert, 1, 1]) * singp.vmat[ipert0, ipert0, 2, 1]
     singp.vmat[ipert0, :, :, 1] ./= sqrt(det)
 
-    # Higher order solutions
+    # Higher order solutions - need to solve iteratively
     for k in 1:2*ctrl.sing_order
         sing_solve!(singp, intr, k)
     end
@@ -222,14 +225,21 @@ end
 """
     sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, ising::Int)
 
-Calculate asymptotic mmat matrix for singular surface `ising`.
-Performs the same function as `sing_mmat` in the Fortran code.
-Main differences are 1-indexing for the expansion orders and
-using dense matrices instead of banded. We keep the Fortran
-convention of only filling in the lower half of the Hermitian
-matrices, and wrap the subsequent multiplications in `Hermitian()`
-calls to take advantage of the symmetry. We have tried to be explicit
-in which matrices have only their lower triangle stored to avoid confusion.
+Calculate asymptotic mmat matrix for singular surface `ising`. Performs the same
+function as `sing_mmat` in the Fortran code. Main differences are 1-indexing for
+the expansion orders and using dense matrices instead of banded. We keep the Fortran
+convention of only filling in the lower half of the Hermitian matrices, and wrap the
+subsequent multiplications in `Hermitian()` calls to take advantage of the symmetry.
+We have tried to be explicit in which matrices have only their lower triangle stored
+to avoid confusion.
+
+More specifically, in this function we construct the Taylor series M_k of the matrix M
+(eq. 43-44 in Glasser 2016). This involves: evaluating the cubic splines and their
+derivatives at the singular surface, constructing the Taylor series coefficients for each
+composite matrix (simple for G, more complicated for F and K since they are stored as
+their nonsingular forms and need to be multiplied by Q, which is itself a Taylor series
+so the coefficients get complicated), solving x = L v for each order in the Taylor series,
+and then reconstructing mmat from x.
 
 ### Arguments
 
@@ -239,6 +249,8 @@ in which matrices have only their lower triangle stored to avoid confusion.
 
 Check third derivative accuracy in cubic splines or determine if it matters
 Better way to unpack the cubic splines
+Rename variables to be more intuitive? I don't like ff - maybe f and f_fact instead of f_lower
+Add a spline for F directly instead of the lower triangular factorization to avoid complexity?
 """
 function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, ising::Int)
 
@@ -267,19 +279,26 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
     g_interp[:, :, 1], g_interp[:, :, 2], g_interp[:, :, 3], g_interp[:, :, 4] = Spl.spline_deriv3!(ffit.gmats, singp.psifac)
     k_interp[:, :, 1], k_interp[:, :, 2], k_interp[:, :, 3], k_interp[:, :, 4] = Spl.spline_deriv3!(ffit.kmats, singp.psifac)
 
-    # Evaluate singfac and its derivatives
-    ipert0 = singp.m - intr.mlow + 1
-    mvec = intr.mlow:intr.mhigh
-    singfac[:, 1] .= mvec .- ctrl.nn * q[1]
+    # Evaluate Taylor series coefficients for diagonal matrix Qᵢ = mᵢ - nᵢq(ψ) = [mᵢ - nᵢq, -nᵢq', -nᵢq'', -nᵢq''']
+    singfac[:, 1] .= intr.mlow:intr.mhigh .- ctrl.nn * q[1]
     singfac[:, 2] .= -ctrl.nn * q[2]
     singfac[:, 3] .= -ctrl.nn * q[3]
     singfac[:, 4] .= -ctrl.nn * q[4]
+    # For resonant modes mᵢ - nᵢq(ψ) = [-nᵢq', -nᵢq'', -nᵢq'''] - shift up terms by 1 index
+    # Add scaling to account for hardcoding coefficients in computations below
+    ipert0 = singp.m - intr.mlow + 1
     singfac[ipert0, 1] = -ctrl.nn * q[2]
     singfac[ipert0, 2] = -ctrl.nn * q[3] / 2
     singfac[ipert0, 3] = -ctrl.nn * q[4] / 3
     singfac[ipert0, 4] = 0
 
-    # Compute factored Hermitian F and its derivatives (lower half only)
+    # This section becomes tricky because we need to reform F = QL̄L̄ᴴQᴴ
+    # TODO: this section can absolutely be simplified using some intuition on the coefficients.
+    # Possibly could just store an unfactorized F spline? Then logic would just look like K but
+    # with an extra singfac/altered coefficients since it would just be F = QF̄Q
+    # For now, leaving overly detailed comments to remind so I don't have to work through this again
+    # First, compute Taylor series coefficients of QL̄ (but without scaling by 1/n!), so we get binomial coefficients leftover
+    # f_lower = QL̄ = [QL̄, QL̄' + Q' L̄, 1/2 (QL̄'' + 2Q' L̄' + QQ'' L̄), 1/6 (QL̄''' + 3Q' L̄'' + 3Q'' L̄' + Q'''L̄), ...] (but without 1/2, 1/6, etc)
     for jpert in 1:intr.mpert
         for ipert in jpert:min(intr.mpert, jpert + intr.mband)
             f_lower[ipert, jpert, 1] = singfac[ipert, 1] * f_lower_interp[ipert, jpert, 1]
@@ -317,10 +336,9 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
     end
     @views f0_lower .= f_lower[:, :, 1]
 
-    # Compute product (lower half only) of Hermitian matrix F
-    # When we wrap the matrix multiplications later with Hermitian(ff),
-    # Julia will handle filling the upper half via the Hermitian property
-    # internally, just like LAPACK does in Fortran
+    # Compute Taylor series coefficients of F = QL̄L̄ᴴQᴴ (lower half only due to indexing) from QL̄ computed above
+    # Here, we build in the Taylor series coefficients iteratively (fac1 = (n choose j), fac0 = 1/n!)
+    # so the final coefficient is 1/(n-j)!j! as desired (and hardcoded in the K computation below)
     fac0 = 1
     for n in 0:ctrl.sing_order
         fac1 = 1
@@ -338,7 +356,8 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         fac0 *= (n + 1)
     end
 
-    # Compute non-Hermitian matrix K
+    # Compute non-Hermitian matrix K = QK̄ Taylor series coefficients
+    # K = [QK̄, QK̄' + Q'K̄, QK̄''/2 + Q'K̄' + Q̄''K̄/2, ...]
     for jpert in 1:intr.mpert
         for ipert in max(1, jpert - intr.mband):min(intr.mpert, jpert + intr.mband)
             k[ipert, jpert, 1] = singfac[ipert, 1] * k_interp[ipert, jpert, 1]
@@ -375,7 +394,8 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         end
     end
 
-    # Compute Hermitian matrix G (lower half only)
+    # Compute Hermitian matrix G (lower half only) Taylor series coefficients
+    # G = [G, G', G''/2, G'''/6]
     for jpert in 1:intr.mpert
         for ipert in jpert:min(intr.mpert, jpert + intr.mband)
             g_lower[ipert, jpert, 1] = g_interp[ipert, jpert, 1]
@@ -394,20 +414,21 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         end
     end
 
-    # Compute identity
+    # We will now compute the Taylor series expansion of x = Lv, with L specified in eq. 23 of Glasser 2016
+    # Start with the identity matrix (which can be indexed to project onto resonant/nonresonant modes)
     for ipert in 1:intr.mpert
         v[ipert, ipert, 1] = 1
         v[ipert, ipert+intr.mpert, 2] = 1
     end
 
-    # Compute zeroth-order x1
+    # Solve the Taylor expansion according to F * x¹ = v² - K v¹ at each order
+    # 0ᵗʰ order: x¹₀ = F⁻¹(v² - K v¹)
     for isol in 1:2*intr.mpert
         @views x[:, isol, 1, 1] .= v[:, isol, 2] .- k[:, :, 1] * v[:, isol, 1]
     end
-    # f is prefactorized so can just use this calculation to get F⁻¹x
     @views x[:, :, 1, 1] = UpperTriangular(f0_lower') \ (LowerTriangular(f0_lower) \ x[:, :, 1, 1])
 
-    # Compute higher-order x1
+    # Higher-order: ∑Fⱼx¹ₙ₋ⱼ = -Kₙv¹ → x¹ₙ = F₀⁻¹(-∑Fⱼxₙ₋ⱼ - Kₙv¹)
     for i in 1:ctrl.sing_order
         for isol in 1:2*intr.mpert
             for j in 1:i
@@ -418,32 +439,38 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
         @views x[:, :, 1, i+1] = UpperTriangular(f0_lower') \ (LowerTriangular(f0_lower) \ x[:, :, 1, i+1])
     end
 
-    # Compute x2
+    # Solve x²ₙ = (G - K^†F⁻¹K)v¹ + K^†F⁻¹v² = Gₙv¹ + ∑Kⱼ^† x¹ₙ₋ⱼ at each order
     for i in 0:ctrl.sing_order
         for isol in 1:2*intr.mpert
             for j in 0:i
-                x[:, isol, 2, i+1] .+= k[:, :, j+1]' * x[:, isol, 1, i-j+1]
+                x[:, isol, 2, i+1] .+= adjoint(k[:, :, j+1]) * x[:, isol, 1, i-j+1]
             end
             x[:, isol, 2, i+1] .+= Hermitian(g_lower[:, :, i+1], :L) * v[:, isol, 1]
         end
     end
 
-    # Principal terms of mmat
+    # Assemble power series coefficients of M = zS⁻¹(LS - S') at each order in √z
+    # eq. 28 in Glasser 2023 PoP paper
     singp.mmat .= 0
     r1 = singp.r1
     r2 = singp.r2
     n1 = singp.n1
     n2 = singp.n2
     j = 0
+    # Start with the S⁻¹LS components
+    # Glasser PoP 2023 eq. 39: at each other of L, we get contributions to z^k from RLR,
+    # z^k+0.5 from RLA and ALR, and z^k+1 from ALA (where A is the nonresonant part)
     for i in 0:ctrl.sing_order
         singp.mmat[r1, r2, :, j+1] .= x[r1, r2, :, i+1]
         singp.mmat[r1, n2, :, j+2] .= x[r1, n2, :, i+1]
         singp.mmat[n1, r2, :, j+2] .= x[n1, r2, :, i+1]
         singp.mmat[n1, n2, :, j+3] .= x[n1, n2, :, i+1]
+        # Expansion of M is in half powers of z due to shearing transformation, so we jump by 2
         j += 2
     end
 
-    # Shearing terms
+    # Apply the effect of the shearing transformation to the resonant indices R
+    # Glasser PoP 2023 eq. 25 + 28: M = zS⁻¹LS - zS⁻¹S' = zS⁻¹LS + 0.5 [R, 0; 0, -R], 0ᵗʰ order only
     singp.mmat[r1, r2[1], 1, 1] .+= 0.5
     singp.mmat[r1, r2[2], 2, 1] .-= 0.5
 end
@@ -457,13 +484,16 @@ See equation 47 in the Glass 2016 DCON paper. Identical to the Fortran
 
 ## Arguments
 
-  - `singp::SingType`: The singularity data structure containing all relevant matrices and parameters.
+  - `singp::SingType`: The singular surface data structure containing all relevant matrices and parameters.
   - `k::Int`: The current order in the power series expansion.
 """
 function sing_solve!(singp::SingType, intr::DconInternal, k::Int)
+    # TODO: rename this solver_higher_order_vmat?
+    # Compute ∑Mₗvₖ₋ₗ
     for l in 1:k
         singp.vmat[:, :, :, k+1] .+= sing_matmul(singp.mmat[:, :, :, l+1], singp.vmat[:, :, :, k-l+1])
     end
+    # Solve a = M₀ - (α + k/2)I = ∑Mₗvₖ₋ₗ
     for isol in 1:2*intr.mpert
         a = copy(singp.m0mat)
         a[1, 1] -= k / 2.0 + singp.power[isol]
@@ -519,10 +549,11 @@ end
 """
     sing_get_ua(ctrl::DconControl, intr::DconInternal, odet::OdeState)
 
-Compute the asymptotic series solution for a given singularity.
-Fills and returns `ua` with the asymptotic solution vmat
-for the specified singular surface and psi value. Performs
-the same function as `sing_get_ua` in the Fortran code.
+Compute the asymptotic series solution for a given singular surface.
+Fills and returns `ua` with the asymptotic solution vmat computed in
+`sing_vmat`. We obtain the solution using equations 45 and 41 in the
+2016 DCON paper. Performs the same function as `sing_get_ua` in the
+Fortran code.
 """
 function sing_get_ua(ctrl::DconControl, intr::DconInternal, odet::OdeState)
 
@@ -530,22 +561,24 @@ function sing_get_ua(ctrl::DconControl, intr::DconInternal, odet::OdeState)
     r1 = singp.r1
     r2 = singp.r2
 
-    # Compute distance from singular surface
+    # Compute distance from singular surface (z)
     dpsi = odet.psifac - singp.psifac
     sqrtfac = sqrt(complex(dpsi))
-    pfac = abs(dpsi)^singp.alpha
 
-    # Compute power series via Horner's method
+    # Compute power series via Horner's method (eq. 45 in Glasser 2016)
     ua = copy(singp.vmat[:, :, :, 2*ctrl.sing_order+1])
     for iorder in (2*ctrl.sing_order-1):-1:0
-        ua .= ua .* sqrtfac .+ singp.vmat[:, :, :, iorder+1]
+        ua .= ua .* sqrtfac .+ singp.vmat[:, :, :, iorder+1] # sqrtfac becomes √zᵏ here
     end
 
-    # Restore powers
-    ua[r1, :, 1] ./= sqrtfac
-    ua[r1, :, 2] .*= sqrtfac
+    # Form full power series solution for v by multiplying by zᵅ (eq. 45 in Glasser 2016)
+    pfac = abs(dpsi)^singp.alpha
     ua[:, r2[1], :] ./= pfac
     ua[:, r2[2], :] .*= pfac
+
+    # Apply shearing transformation u = Rv (eq. 41 in Glasser 2016)
+    ua[r1, :, 1] ./= sqrtfac
+    ua[r1, :, 2] .*= sqrtfac
 
     # Renormalize
     if odet.psifac < singp.psifac
@@ -631,10 +664,15 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
         FourFitVars,DconInternal,OdeState},
     psieval::Float64)
 
-    # Unpack structs
+    # Unpack structs and initialize
     ctrl, equil, ffit, intr, odet = params
+    fill!(odet.tmp, 0)
+    u1 = @view(u[:, :, 1])
+    u2 = @view(u[:, :, 2])
+    du1 = @view(du[:, :, 1])
+    du2 = @view(du[:, :, 2])
 
-    # Spline evaluation
+    # Compute singfac = 1 / (m - nq)
     odet.q = Spl.spline_eval!(equil.sq, psieval)[4]
     odet.singfac_vec .= 1.0 ./ (intr.mlow .- ctrl.nn * odet.q .+ (0:intr.mpert-1))
     chi1 = 2π * equil.psio
@@ -644,7 +682,6 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
         error("kin_flag not implemented yet")
     else
         # Evaluate splines at psieval and reshape avoiding new allocations
-        # TODO: is this actually more efficient?
         Spl.spline_eval!(odet.amat, ffit.amats, psieval)
         amat = reshape(odet.amat, intr.mpert, intr.mpert)
         Spl.spline_eval!(odet.bmat, ffit.bmats, psieval)
@@ -667,36 +704,32 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
         ldiv!(odet.Afact, cmat)
     end
 
-    odet.tmp .= 0
-    u1 = @view(u[:, :, 1])
-    u2 = @view(u[:, :, 2])
     # Compute du
     if false #(TODO: kin_flag)
         error("kin_flag not implemented yet")
     else
-        # See equation 23 in Glasser 2016 DCON paper for derivation
-        # du[1] = - K * u[1] + u[2]
-
-        du[:, :, 1] .= u2 .* odet.singfac_vec
+        # See equations 22-24 in Glasser 2016 DCON paper for derivation
+        # du[1] = - K̄ * u[1] + Q⁻¹ * u[2]
+        du1 .= u2 .* odet.singfac_vec
         mul!(odet.tmp, kmat, u1)
-        @views du[:, :, 1] .-= odet.tmp
-
-        # du[1] = - F⁻¹ * K * u[1] + F⁻¹ * u[2] (remember F is already stored in factored form)
-        @views ldiv!(LowerTriangular(fmat_lower), du[:, :, 1])
-        @views ldiv!(UpperTriangular(fmat_lower'), du[:, :, 1])
-
-        # du[2] = G * u[1] + K' * du[1] = G * u[1] - K^† * F⁻¹ * K * u[1] + K^† * F⁻¹ * u[2]
+        du1 .-= odet.tmp
+        # du[1] = - F̄⁻¹ * K̄ * u[1] + F̄⁻¹ * Q⁻¹ * u[2]
+        ldiv!(LowerTriangular(fmat_lower), du1)
+        ldiv!(UpperTriangular(fmat_lower'), du1)
+        # du[2] = G * u[1] + K̄^† * du[1] = G * u[1] - K̄^† * F̄⁻¹ * K̄ * u[1] + K̄^† * F̄⁻¹ * Q⁻¹ * u[2]
         mul!(odet.tmp, gmat, u1)
-        @views du[:, :, 2] .= odet.tmp
-        @views mul!(odet.tmp, adjoint(kmat), du[:, :, 1])
-        @views du[:, :, 2] .+= odet.tmp
-        @views du[:, :, 1] .*= odet.singfac_vec
+        du2 .= odet.tmp
+        mul!(odet.tmp, adjoint(kmat), du1)
+        du2 .+= odet.tmp
+        # du[1] = - Q⁻¹ * F̄⁻¹ * K̄ * u[1] + Q⁻¹ * F̄⁻¹ * Q⁻¹ * u[2]
+        du1 .*= odet.singfac_vec
     end
 
-    # u-derivative used in GPEC
-    @views odet.ud[:, :, 1] .= du[:, :, 1]
-    @views mul!(odet.tmp, bmat, du[:, :, 1])
+    # ud[1] = Ξ'_Ψ
+    @views odet.ud[:, :, 1] .= du1
+    # ud[2] = Ξ_s = - A⁻¹(B * Ξ'_Ψ - C * Ξ_Ψ), equation 18 of Glasser 2016
+    mul!(odet.tmp, bmat, du1)
     odet.ud[:, :, 2] .= .-odet.tmp
-    @views mul!(odet.tmp, cmat, u[:, :, 1])
+    mul!(odet.tmp, cmat, u1)
     @views odet.ud[:, :, 2] .-= odet.tmp
 end

--- a/src/DCON/Sing.jl
+++ b/src/DCON/Sing.jl
@@ -674,7 +674,7 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
 
     # Compute singfac = 1 / (m - nq)
     odet.q = Spl.spline_eval!(equil.sq, psieval)[4]
-    odet.singfac_vec .= 1.0 ./ (intr.mlow .- ctrl.nn * odet.q .+ (0:intr.mpert-1))
+    odet.singfac_vec .= 1.0 ./ (collect(intr.mlow:intr.mhigh) .- ctrl.nn * odet.q )
     chi1 = 2π * equil.psio
 
     # kinetic stuff - skip for now
@@ -695,8 +695,6 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
         Spl.spline_eval!(odet.gmat, ffit.gmats, psieval)
         gmat = reshape(odet.gmat, intr.mpert, intr.mpert)
 
-        # ldiv!(A,B): Compute A \ B in-place and overwriting B to store the result,
-        # where A is a factorization object.
         odet.Afact = cholesky(Hermitian(amat))
         # bmat = A⁻¹ * bmat
         ldiv!(odet.Afact, bmat)
@@ -709,11 +707,10 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
         error("kin_flag not implemented yet")
     else
         # See equations 22-24 in Glasser 2016 DCON paper for derivation
-        # du[1] = - K̄ * u[1] + Q⁻¹ * u[2]
+        # du[1] = - F̄⁻¹ * K̄ * u[1] + F̄⁻¹ * Q⁻¹ * u[2]
         du1 .= u2 .* odet.singfac_vec
         mul!(odet.tmp, kmat, u1)
         du1 .-= odet.tmp
-        # du[1] = - F̄⁻¹ * K̄ * u[1] + F̄⁻¹ * Q⁻¹ * u[2]
         ldiv!(LowerTriangular(fmat_lower), du1)
         ldiv!(UpperTriangular(fmat_lower'), du1)
         # du[2] = G * u[1] + K̄^† * du[1] = G * u[1] - K̄^† * F̄⁻¹ * K̄ * u[1] + K̄^† * F̄⁻¹ * Q⁻¹ * u[2]
@@ -727,7 +724,7 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
 
     # ud[1] = Ξ'_Ψ
     @views odet.ud[:, :, 1] .= du1
-    # ud[2] = Ξ_s = - A⁻¹(B * Ξ'_Ψ - C * Ξ_Ψ), equation 18 of Glasser 2016
+    # ud[2] = Ξ_s = - A⁻¹(B * Ξ'_Ψ - C * Ξ_Ψ), eq. 18 of Glasser 2016
     mul!(odet.tmp, bmat, du1)
     odet.ud[:, :, 2] .= .-odet.tmp
     mul!(odet.tmp, cmat, u1)

--- a/src/DCON/Sing.jl
+++ b/src/DCON/Sing.jl
@@ -46,7 +46,7 @@ function sing_find!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
             converged = false
             for _ in 1:itmax
                 psifac = (psi0 + psi1) / 2
-                singfac = (m - n * Spl.spline_eval!(equil.sq, psifac)[4]) * dm
+                singfac = (m - ctrl.nn * Spl.spline_eval!(equil.sq, psifac)[4]) * dm
                 abs(singfac) < 1e-8 && (converged = true; break)
                 singfac > 0 ? (psi0 = psifac) : (psi1 = psifac)
             end
@@ -280,7 +280,7 @@ function sing_mmat!(intr::DconInternal, ctrl::DconControl, equil::Equilibrium.Pl
     k_interp[:, :, 1], k_interp[:, :, 2], k_interp[:, :, 3], k_interp[:, :, 4] = Spl.spline_deriv3!(ffit.kmats, singp.psifac)
 
     # Evaluate Taylor series coefficients for diagonal matrix Qᵢ = mᵢ - nᵢq(ψ) = [mᵢ - nᵢq, -nᵢq', -nᵢq'', -nᵢq''']
-    singfac[:, 1] .= intr.mlow:intr.mhigh .- ctrl.nn * q[1]
+    singfac[:, 1] .= collect(intr.mlow:intr.mhigh) .- ctrl.nn .* q[1]
     singfac[:, 2] .= -ctrl.nn * q[2]
     singfac[:, 3] .= -ctrl.nn * q[3]
     singfac[:, 4] .= -ctrl.nn * q[4]


### PR DESCRIPTION
This is a PR of code cleanups I encountered while implementing multi-n but were not directly related to the implementation. A significant portion is spent on adding more verbose comments/directly linking code to equations in the DCON paper.

Additional cleanups:

- Deprecating some more unused stuff in `Free.jl`, including the `ahg` file interface, netCDF output, and `vac.bin` output
- Standardizing control logic for Newton/binary searches
- Making the `path` variable default to the current run directory
- Deprecating `m1` and `singfac` within the OdeState struct, they didn't serve a purpose and become confusing for multi-n