### PR TITLE
Removing x_wall < 0 logic

### DIFF
--- a/src/Vacuum/VacuumInternals.jl
+++ b/src/Vacuum/VacuumInternals.jl
@@ -109,23 +109,6 @@ function kernel!(
     log_correction_1=128.0*dtheta*(log(2*dtheta)-8.0/15.0)/45.0
     log_correction_2=4.0*dtheta*(7.0*log(2*dtheta)-11.0/15.0)/45.0
 
-    has_zero_crossing = false
-    # See if the conductor surface crosses R=0 (x=0) anywhere
-    if !plasma_plasma_block
-        # Initialize jbot and jtop, and figure out wall geometry based on which block we are in
-        jbot = jtop = mtheta/2+1
-        xwall = plasma_is_source ? x_obspoints : x_sourcepoints
-        # Find if sign of wall x point crosses zero
-        for i in 1:mtheta
-            next_i = i == mtheta ? 1 : i + 1
-            if xwall[i] * xwall[next_i] <= 0.0
-                jbot = xwall[i] > 0.0 ? i : # index where the wall leaves positive R
-                       jtop = xwall[i] < 0.0 ? i + 1 : jtop # index where the wall returns to positive R
-                has_zero_crossing = true
-            end
-        end
-    end
-
     # Used for Z'_θ and X'_θ in eq.(51)
     spline_x = cubic_spline_interpolation(theta_grid, x_sourcepoints; extrapolation_bc=Interpolations.Periodic())
     spline_z = cubic_spline_interpolation(theta_grid, z_sourcepoints; extrapolation_bc=Interpolations.Periodic())
@@ -142,69 +125,34 @@ function kernel!(
         # Workspace = view of appropriate row of grad_greenfunction_mat for this observer point
         grad_green_work = @view(grad_greenfunction_mat[(j1-1)*mtheta+j, (j2-1)*mtheta .+ (1:mtheta)])
 
-        # if observation point is negative, we cannot use green function
-        if x_obs < 0.0
-            !plasma_is_source && (grad_green_work[j] = 1.0)
-            continue
-        end
+        # Obtain nonsingular region (endpoints at j+2 and j-2, so exclude j-1, j, and j+1)
+        nonsing_src_indices = mod1.((j+2):(j+mtheta-2), mtheta) # mod1 ensures isrc is in [1, mtheta]
 
-        # Compute istart and iend (start/end index of integration to avoid singularity)
-        # If no zero crossing, istart = iend = 2
-        iend = 2
-        if has_zero_crossing && !plasma_is_source
-            # Determine iend/istart so Simpson sweep avoids integrating across the (x=0) discontinuity near the observer index j
-            if jbot - j == 1
-                iend = 3
-            elseif jbot - j == 0
-                iend = 4
-            elseif j - jtop == 0
-                iend = 0
-            elseif j - jtop == 1
-                iend = 1
-            end
-        end
-        istart = 4 - iend
+        # Compute composite Simpson's 1/3 rule weights (https://en.wikipedia.org/wiki/Simpson%27s_rule#Composite_Simpson's_1/3_rule)
+        # Note we set to 4 for even/2 for odd since we index from 1 while the formula assumes indexing from 0
+        nsrc = length(nonsing_src_indices)
+        simpson_weights = dtheta / 3 .* [(k == 1 || k == nsrc) ? 1 : (iseven(k) ? 4 : 2) for k in 1:nsrc]
 
-        # Perform Simpson integration for nonsingular source points (excludes 3 singular points)
-        # For cases where wall doesn't cross x=0 (iend = istart = 2), the singular points are j-1, j, j+1
-        for i in 1:(mtheta-3)
-            # Get source point index (ic) and ensure it is in range [1, mtheta]
-            ic = i + j + istart - 1
-            if ic > mtheta
-                ic = ic - mtheta
-            end
-            x_source=x_sourcepoints[ic]
-            z_source=z_sourcepoints[ic]
-
-            # if source point is negative, we cannot use green function
-            # & if source point(ic) and obs point (j) is same, it's singular
-            (x_source < 0 || ic == j) && continue
+        # Perform Simpson integration for nonsingular source points
+        for (isrc, wsimpson) in zip(nonsing_src_indices, simpson_weights)
+            x_source=x_sourcepoints[isrc]
+            z_source=z_sourcepoints[isrc]
 
             # G_n is 2pi𝒢ⁿ; coupling_n is 𝒥 ∇'𝒢ⁿ∇'ℒ; coupling_0 is 𝒥 ∇'𝒢ⁿ∇'ℒ for n=0
-            G_n, coupling_n, coupling_0 = green(x_obs, z_obs, x_source, z_source, dx_dtheta[ic], dz_dtheta[ic], n)
-
-            # Compute composite Simpson's 1/3 rule weight (https://en.wikipedia.org/wiki/Simpson%27s_rule#Composite_Simpson's_1/3_rule)
-            # Note we set to 4 for even/2 for odd since we index from 1 while the formula assumes indexing from 0
-            endpoint = (i == 1)||(i == mtheta - 3)
-            wsimpson = (endpoint ? 1 : (iseven(i) ? 4 : 2)) * dtheta / 3
+            G_n, coupling_n, coupling_0 = green(x_obs, z_obs, x_source, z_source, dx_dtheta[isrc], dz_dtheta[isrc], n)
 
             # Sum contributions to Green's function matrices using Simpson weight
-            grad_green_work[ic] += isgn * coupling_n * wsimpson
-            greenfunction_mat[j, ic] += G_n * wsimpson
+            grad_green_work[isrc] += isgn * coupling_n * wsimpson
+            greenfunction_mat[j, isrc] += G_n * wsimpson
             grad_green_0 += coupling_0 * wsimpson
         end
 
-        # Skip singularity calculation for R < 0 wall points
-        if has_zero_crossing && j > jbot && j < jtop
-            continue
-        end
-
         # Perform Gaussian quadrature for singular points (source = obs point)
-        # Get indices of the singularity region ([j-2, j-1, j, j+1, j+2] for iend = 2)
-        js = mod.(j - iend .+ ((mtheta-1):(mtheta+3)), mtheta) .+ 1
-        # Integrate region of length 2 * dtheta on left (ilr = 1)/right (ilr = 2) of singularity
-        for ilr in [1, 2]
-            gauss_xleft = theta_obs + (2*ilr-iend-2)*dtheta
+        # Get indices of the singularity region, [j-2, j-1, j, j+1, j+2]
+        js = mod.(j .+ ((mtheta-3):(mtheta+1)), mtheta) .+ 1
+        # Integrate region of length 2 * dtheta on left/right of singularity
+        for region in ["left", "right"]
+            gauss_xleft = theta_obs - (region == "left" ? 2 * dtheta : 0)
             gauss_xright = gauss_xleft + 2 * dtheta
             gauss_xavg = (gauss_xright + gauss_xleft)/2
             theta_gauss = gauss_xavg .+ GAUSSIANPOINTS .* dtheta # tgaus is 8 point gauss points, since GAUSSIANPOINTS is for only [-1,1]
@@ -222,8 +170,8 @@ function kernel!(
 
                 # Redefine hardcoded Gaussian weights on the interval [-1, 1] to physical interval with length 2 * dtheta
                 wgauss = GAUSSIANWEIGHTS[ig] * dtheta
-                # Calculate p = θ/Δ = (θⱼ - θ')/Δ, 0 at observation point, ±1,±2 at other 5-point stencil nodes
-                pgauss=(theta_gauss[ig]-theta_obs-(2-iend)*dtheta)/dtheta
+                # Calculate p = θ/Δ = (θⱼ - θ')/Δ
+                pgauss=(theta_gauss[ig]-theta_obs)/dtheta
                 # Compute 5-point Lagrange basis polynomials at the Gauss point and multiply by quadrature weight
                 A0 = (pgauss^2-1)*(pgauss^2-4)/4.0 * wgauss
                 A1_plus = -(pgauss+1)*pgauss*(pgauss^2-4)/6.0 * wgauss
@@ -241,7 +189,7 @@ function kernel!(
                 end
 
                 # Second type of singularity: 𝒦ⁿ
-                # Eq. 86: 𝒦ⁿαᵢ - δⱼᵢK⁰ (js[3] = j if iend=2)
+                # Eq. 86: 𝒦ⁿαᵢ - δⱼᵢK⁰
                 grad_green_work[js[1]] += isgn * coupling_n * A2_minus
                 grad_green_work[js[2]] += isgn * coupling_n * A1_minus
                 grad_green_work[js[3]] += isgn * coupling_n * A0

--- a/src/Vacuum/VacuumStructs.jl
+++ b/src/Vacuum/VacuumStructs.jl
@@ -370,6 +370,7 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
     end
 
     if any(x_wall .<= 0.0) && !nowall
+        # to add support for x<0 walls, be sure to carefully replicate Chance's fortran code x<0 handling in the kernel function to account for the additional singularities associated with this
         error("Wall R-coordinates contain non-physical values (R <= 0). Check wall geometry.")
     end
 

--- a/src/Vacuum/VacuumStructs.jl
+++ b/src/Vacuum/VacuumStructs.jl
@@ -291,8 +291,8 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
             z_wall[i] = z_plasma[i] + a * r_minor * sin(alph)
         end
 
-        if any(x_wall .== centerstack_min)
-            @warn "Conformal wall with a=$a would cross R=0 axis; forcing minimum wall R to $centerstack_min to avoid unphysical geometry."
+        if any(x_wall .<= centerstack_min + eps(Float64))
+            @warn "Conformal wall with a=$a would cross R=0 axis; forcing minimum wall R to $(@sprintf "%.2e" centerstack_min) m to avoid unphysical geometry."
         end
 
     elseif wall_settings.shape == "elliptical"

--- a/src/Vacuum/VacuumStructs.jl
+++ b/src/Vacuum/VacuumStructs.jl
@@ -5,18 +5,18 @@ Struct holding plasma boundary and mode data as provided from DCON namelist and 
 
 # Fields
 
-- `r::Vector{Float64}`: Plasma boundary R-coordinate as a function of poloidal angle
-- `z::Vector{Float64}`: Plasma boundary Z-coordinate as a function of poloidal angle
-- `delta::Vector{Float64}`: Toroidal angle offset: -dφ/qa; 0 for coordinate systems using machine angle (e.g., PEST basis)
-- `mlow::Int`: Lower poloidal mode number for spectral representation
-- `mhigh::Int`: Upper poloidal mode number for spectral representation
-- `mpert::Int`: Number of perturbation modes (mhigh - mlow + 1)
-- `n::Int`: The toroidal mode number
-- `qa::Float64`: Safety factor at the plasma boundary
-- `mtheta_eq::Int`: Number of poloidal angles in the input equilibrium boundary arrays
-- `mtheta::Int`: Number of poloidal grid points for vacuum calculations
-- `kernelsign::Float64`: Sign for kernel; +1 or -1, only ≠ 1 for mutual inductance calculations
-- `force_wv_symmetry::Bool`: Boolean flag to enforce symmetry in the vacuum response matrix (set in dcon.toml)
+  - `r::Vector{Float64}`: Plasma boundary R-coordinate as a function of poloidal angle
+  - `z::Vector{Float64}`: Plasma boundary Z-coordinate as a function of poloidal angle
+  - `delta::Vector{Float64}`: Toroidal angle offset: -dφ/qa; 0 for coordinate systems using machine angle (e.g., PEST basis)
+  - `mlow::Int`: Lower poloidal mode number for spectral representation
+  - `mhigh::Int`: Upper poloidal mode number for spectral representation
+  - `mpert::Int`: Number of perturbation modes (mhigh - mlow + 1)
+  - `n::Int`: The toroidal mode number
+  - `qa::Float64`: Safety factor at the plasma boundary
+  - `mtheta_eq::Int`: Number of poloidal angles in the input equilibrium boundary arrays
+  - `mtheta::Int`: Number of poloidal grid points for vacuum calculations
+  - `kernelsign::Float64`: Sign for kernel; +1 or -1, only ≠ 1 for mutual inductance calculations
+  - `force_wv_symmetry::Bool`: Boolean flag to enforce symmetry in the vacuum response matrix (set in dcon.toml)
 """
 @kwdef mutable struct VacuumInput
     r::Vector{Float64} = Float64[]
@@ -36,23 +36,23 @@ end
 """
     PlasmaGeometry
 
-Struct holding plasma geometry data on the mtheta grid for vacuum calculations. 
+Struct holding plasma geometry data on the mtheta grid for vacuum calculations.
 
 Arrays are of length `mtheta`, where `mtheta` is the number of poloidal grid points and θ ∈ [0, 1).
 
 # Fields
 
-- `x::Vector{Float64}`: Plasma surface R-coordinate
-- `z::Vector{Float64}`: Plasma surface Z-coordinate
-- `delta::Vector{Float64}`: Toroidal angle offset divided by qa (i.e., -ν/qa where ϕ = 2πζ + ν(ψ, θ)) at plasma surface
-- `dx_dtheta::Vector{Float64}`: Derivative dR/dθ at plasma surface
-- `dz_dtheta::Vector{Float64}`: Derivative dZ/dθ at plasma surface
-- `cnqd::Vector{Float64}`: cos(n * qa * delta) at plasma surface
-- `snqd::Vector{Float64}`: sin(n * qa * delta) at plasma surface
-- `sinlt::Matrix{Float64}`: sin(l * θ) basis functions for poloidal modes at plasma surface
-- `coslt::Matrix{Float64}`: cos(l * θ) basis functions for poloidal modes at plasma surface
-- `snlth::Matrix{Float64}`: sin(l * θ + n * qa * delta) basis functions for poloidal modes at plasma surface
-- `cslth::Matrix{Float64}`: cos(l * θ + n * qa * delta) basis functions for poloidal modes at plasma surface
+  - `x::Vector{Float64}`: Plasma surface R-coordinate
+  - `z::Vector{Float64}`: Plasma surface Z-coordinate
+  - `delta::Vector{Float64}`: Toroidal angle offset divided by qa (i.e., -ν/qa where ϕ = 2πζ + ν(ψ, θ)) at plasma surface
+  - `dx_dtheta::Vector{Float64}`: Derivative dR/dθ at plasma surface
+  - `dz_dtheta::Vector{Float64}`: Derivative dZ/dθ at plasma surface
+  - `cnqd::Vector{Float64}`: cos(n * qa * delta) at plasma surface
+  - `snqd::Vector{Float64}`: sin(n * qa * delta) at plasma surface
+  - `sinlt::Matrix{Float64}`: sin(l * θ) basis functions for poloidal modes at plasma surface
+  - `coslt::Matrix{Float64}`: cos(l * θ) basis functions for poloidal modes at plasma surface
+  - `snlth::Matrix{Float64}`: sin(l * θ + n * qa * delta) basis functions for poloidal modes at plasma surface
+  - `cslth::Matrix{Float64}`: cos(l * θ + n * qa * delta) basis functions for poloidal modes at plasma surface
 """
 struct PlasmaGeometry
     x::Vector{Float64}
@@ -71,18 +71,18 @@ end
 """
     WallGeometry
 
-Struct holding wall geometry data for vacuum calculations. 
+Struct holding wall geometry data for vacuum calculations.
 
 Arrays are of length `mtheta`, where `mtheta` is the number of poloidal grid points and θ ∈ [0, 1).
 
 # Fields
 
-- `nowall::Bool`: Boolean flag indicating if there is no wall
-- `is_closed_toroidal::Bool`: Boolean flag indicating if the wall is a closed toroidal surface
-- `x::Vector{Float64}`: Wall R-coordinates
-- `z::Vector{Float64}`: Wall Z-coordinates
-- `dx_dtheta::Vector{Float64}`: Derivative dR/dθ at wall
-- `dz_dtheta::Vector{Float64}`: Derivative dZ/dθ at wall
+  - `nowall::Bool`: Boolean flag indicating if there is no wall
+  - `is_closed_toroidal::Bool`: Boolean flag indicating if the wall is a closed toroidal surface
+  - `x::Vector{Float64}`: Wall R-coordinates
+  - `z::Vector{Float64}`: Wall Z-coordinates
+  - `dx_dtheta::Vector{Float64}`: Derivative dR/dθ at wall
+  - `dz_dtheta::Vector{Float64}`: Derivative dZ/dθ at wall
 """
 @kwdef struct WallGeometry
     nowall::Bool = true
@@ -100,27 +100,29 @@ Struct containing input settings for vacuum wall geometry.
 
 # Fields
 
-- `shape::String`: String selecting wall shape. Options are:
-  - `"nowall"`: No wall
-  - `"conformal"`: Wall conformal to plasma surface at distance `a`
-  - `"elliptical"`: Elliptical wall
-  - `"dee"`: Dee-shaped wall
-  - `"mod_dee"`: Modified Dee-shaped wall
-  - `"filepath"`: Custom wall shape from the file you specify
-- `a::Float64`: Distance of wall from plasma in units of major radius (conformal), or shape parameter (others)
-- `aw::Float64`: Half-thickness parameter for Dee-shaped walls
-- `bw::Float64`: Elongation parameter for wall shapes
-- `cw::Float64`: Offset of the center of the wall from the major radius
-- `dw::Float64`: Triangularity parameter for wall shapes
-- `tw::Float64`: Sharpness of the corners of the wall (try 0.05 as initial value)
-- `equal_arc_wall::Bool`: Flag to enforce equal arc length distribution of nodes on the wall 
-  (recommended unless wall is very close to plasma)
+  - `shape::String`: String selecting wall shape. Options are:
+
+      + `"nowall"`: No wall
+      + `"conformal"`: Wall conformal to plasma surface at distance `a`
+      + `"elliptical"`: Elliptical wall
+      + `"dee"`: Dee-shaped wall
+      + `"mod_dee"`: Modified Dee-shaped wall
+      + `"filepath"`: Custom wall shape from the file you specify
+
+  - `a::Float64`: Distance of wall from plasma in units of major radius (conformal), or shape parameter (others)
+  - `aw::Float64`: Half-thickness parameter for Dee-shaped walls
+  - `bw::Float64`: Elongation parameter for wall shapes
+  - `cw::Float64`: Offset of the center of the wall from the major radius
+  - `dw::Float64`: Triangularity parameter for wall shapes
+  - `tw::Float64`: Sharpness of the corners of the wall (try 0.05 as initial value)
+  - `equal_arc_wall::Bool`: Flag to enforce equal arc length distribution of nodes on the wall
+    (recommended unless wall is very close to plasma)
 """
-@kwdef struct WallShapeSettings 
+@kwdef struct WallShapeSettings
 
     # Core shape selection
     shape::String = "nowall"
-    
+
     # Standard geometric parameters for Dee/Mod-Dee
     a::Float64 = 0.3
     aw::Float64 = 0.05
@@ -128,7 +130,7 @@ Struct containing input settings for vacuum wall geometry.
     cw::Float64 = 0.0
     dw::Float64 = 0.5
     tw::Float64 = 0.05
-    
+
     # Algorithmic options
     equal_arc_wall::Bool = true
 end
@@ -136,26 +138,26 @@ end
 """
     initialize_plasma_surface(inputs::VacuumInput) -> PlasmaGeometry
 
-Initialize the plasma surface geometry based on the provided vacuum inputs. 
+Initialize the plasma surface geometry based on the provided vacuum inputs.
 
-This function performs functionality from `readahg`, `arrays`, and `funint` in the 
+This function performs functionality from `readahg`, `arrays`, and `funint` in the
 original Fortran VACUUM code. It returns a `PlasmaGeometry` struct containing
 the necessary plasma surface data for vacuum calculations.
 
 # Process
 
-1. Interpolate the input plasma boundary arrays onto the mtheta grid
-2. Compute derivatives of the plasma boundary with respect to poloidal angle θ 
-   using periodic cubic spline differentiation
-3. Compute trigonometric basis functions needed for Fourier calculations
+ 1. Interpolate the input plasma boundary arrays onto the mtheta grid
+ 2. Compute derivatives of the plasma boundary with respect to poloidal angle θ
+    using periodic cubic spline differentiation
+ 3. Compute trigonometric basis functions needed for Fourier calculations
 
 # Arguments
 
-- `inputs::VacuumInput`: Struct containing plasma boundary data and calculation parameters
+  - `inputs::VacuumInput`: Struct containing plasma boundary data and calculation parameters
 
 # Returns
 
-- `PlasmaGeometry`: Struct containing plasma surface coordinates, derivatives, and basis functions
+  - `PlasmaGeometry`: Struct containing plasma surface coordinates, derivatives, and basis functions
 """
 function initialize_plasma_surface(inputs::VacuumInput)
 
@@ -166,7 +168,7 @@ function initialize_plasma_surface(inputs::VacuumInput)
     delta = interp_to_new_grid(inputs.delta, mtheta)
     # Plasma boundary theta derivative (this is semi-working)
     # All of these arrays are of length mth with θ = [0, 1)
-    theta_grid = range(start=0, length=mtheta, step=2π/mtheta)
+    theta_grid = range(; start=0, length=mtheta, step=2π/mtheta)
     dx_plasma_dtheta = periodic_cubic_deriv(theta_grid, x_plasma)
     dz_plasma_dtheta = periodic_cubic_deriv(theta_grid, z_plasma)
     # Trigonometric basis arrays
@@ -221,36 +223,36 @@ end
 """
     initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_settings::WallShapeSettings) -> WallGeometry
 
-Initialize the wall geometry based on the provided vacuum inputs and wall shape settings. 
+Initialize the wall geometry based on the provided vacuum inputs and wall shape settings.
 
-This performs functionality similar to portions of the `arrays` function in the original 
-Fortran VACUUM code. It returns a `WallGeometry` struct containing the necessary wall 
+This performs functionality similar to portions of the `arrays` function in the original
+Fortran VACUUM code. It returns a `WallGeometry` struct containing the necessary wall
 surface data for vacuum calculations.
 
 # Arguments
 
-- `inputs::VacuumInput`: Struct containing vacuum calculation parameters
-- `plasma_surf::PlasmaGeometry`: Struct with plasma surface geometry (used for reference)
-- `wall_settings::WallShapeSettings`: Struct specifying wall shape and parameters
+  - `inputs::VacuumInput`: Struct containing vacuum calculation parameters
+  - `plasma_surf::PlasmaGeometry`: Struct with plasma surface geometry (used for reference)
+  - `wall_settings::WallShapeSettings`: Struct specifying wall shape and parameters
 
 # Returns
 
-- `WallGeometry`: Struct containing wall surface coordinates and derivatives
+  - `WallGeometry`: Struct containing wall surface coordinates and derivatives
 
 # Notes
 
-- Supports multiple wall shapes: nowall, conformal, elliptical, dee, mod_dee, from_file
-- Optionally redistributes wall points to equal arc length spacing if `equal_arc_wall=true`
+  - Supports multiple wall shapes: nowall, conformal, elliptical, dee, mod_dee, from_file
+  - Optionally redistributes wall points to equal arc length spacing if `equal_arc_wall=true`
 """
 function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_settings::WallShapeSettings)
-    
+
     # Basic wall flags
     nowall = wall_settings.shape == "nowall"
     is_closed_toroidal = true
 
-   # All of these arrays are of length mtheta with θ = [0, 1)
+    # All of these arrays are of length mtheta with θ = [0, 1)
     mtheta = inputs.mtheta
-    
+
     # Get wall shape from form_wall
     # Plasma surface coordinates
     x_plasma = plasma_surf.x
@@ -258,7 +260,7 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
 
     # Output wall coordinate arrays
     x_wall = zeros(Float64, mtheta)
-    z_wall = zeros(Float64, mtheta)    
+    z_wall = zeros(Float64, mtheta)
 
     # Common geometric parameters
     xmin = minimum(x_plasma)
@@ -268,7 +270,7 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
 
     r_minor = 0.5 * (xmax - xmin)
     r_major = 0.5 * (xmax + xmin)
-    
+
     # Destructuring settings for readability
     (; aw, bw, cw, dw, tw, a) = wall_settings
     wcentr = 0.0 # Initialize
@@ -277,16 +279,20 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
         @info "Using no wall"
     elseif wall_settings.shape == "conformal"
         dx = a * r_minor
-        @info "Calculating conformal wall shape $((@sprintf "%.2e" dx)) m from plasma surface." 
+        @info "Calculating conformal wall shape $((@sprintf "%.2e" dx)) m from plasma surface."
         wcentr = r_major
-        centerstack_min  = min(0.1, 0.1 * minimum(x_plasma))  # Avoid wall crossing R=0 axis
+        centerstack_min = min(0.1, 0.1 * minimum(x_plasma))  # Avoid wall crossing R=0 axis
         for i in 1:mtheta
             j = mod1(i - 1, mtheta)
             k = mod1(i + 1, mtheta)
             # Normal vector calculation
             alph = atan(x_plasma[k] - x_plasma[j], z_plasma[j] - z_plasma[k])
-            x_wall[i] = max(centerstack_min , x_plasma[i] + a * r_minor * cos(alph))
+            x_wall[i] = max(centerstack_min, x_plasma[i] + a * r_minor * cos(alph))
             z_wall[i] = z_plasma[i] + a * r_minor * sin(alph)
+        end
+
+        if any(x_wall .== centerstack_min)
+            @warn "Conformal wall with a=$a would cross R=0 axis; forcing minimum wall R to $centerstack_min to avoid unphysical geometry."
         end
 
     elseif wall_settings.shape == "elliptical"
@@ -295,9 +301,9 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
 
         zrad = 0.5 * (zmax - zmin)
         zh = sqrt(abs(zrad^2 - r_minor^2))
-        zmuw = log((a/zh) + sqrt((a/zh)^2 + 1)) 
-        bw_eff = (zh * cosh(zmuw)) / a 
-        
+        zmuw = log((a/zh) + sqrt((a/zh)^2 + 1))
+        bw_eff = (zh * cosh(zmuw)) / a
+
         for i in 1:mtheta
             the = (i - 1) * (2π / mtheta)
             x_wall[i] = r_major + a * cos(the)
@@ -358,12 +364,15 @@ function initialize_wall(inputs::VacuumInput, plasma_surf::PlasmaGeometry, wall_
         dz_dtheta = only.(Interpolations.gradient.(Ref(fz_of_theta), theta_grid))
     else
         # used regular theta grid spacing to build wall
-        theta_grid = range(0, stop=2π, length=mtheta + 1)[1:end-1] # length mtheta without endpoint
+        theta_grid = range(0; stop=2π, length=mtheta + 1)[1:(end-1)] # length mtheta without endpoint
         dx_dtheta = periodic_cubic_deriv(theta_grid, x_wall)
         dz_dtheta = periodic_cubic_deriv(theta_grid, z_wall)
     end
 
-    # Trigonometric basis arrays
+    if any(x_wall .<= 0.0) && !nowall
+        error("Wall R-coordinates contain non-physical values (R <= 0). Check wall geometry.")
+    end
+
     return WallGeometry(
         nowall,
         is_closed_toroidal,
@@ -377,67 +386,67 @@ end
 """
     distribute_to_equal_arc_grid(xin, zin, mw1)
 
-Perform arc length re-parameterization of a 2D curve. 
+Perform arc length re-parameterization of a 2D curve.
 
 Takes an input curve defined by `(xin, zin)` coordinates and re-samples it such that
 the new points `(xout, zout)` are equally spaced in arc length along the curve.
 
 # Arguments
 
-- `xin::Vector{Float64}`: Array of x-coordinates of the input curve
-- `zin::Vector{Float64}`: Array of z-coordinates of the input curve
-- `mw1::Int`: Number of points in the input and output curves
+  - `xin::Vector{Float64}`: Array of x-coordinates of the input curve
+  - `zin::Vector{Float64}`: Array of z-coordinates of the input curve
+  - `mw1::Int`: Number of points in the input and output curves
 
 # Returns
 
-- `xout::Vector{Float64}`: Array of x-coordinates of the arc-length re-parameterized curve
-- `zout::Vector{Float64}`: Array of z-coordinates of the arc-length re-parameterized curve
-- `ell::Vector{Float64}`: Array of cumulative arc lengths for the input curve
-- `thgr::Vector{Float64}`: Array of re-parameterized 'theta' values corresponding to equal arc lengths
-- `thlag::Vector{Float64}`: Array of normalized 'theta' values for the input curve (0 to 1)
+  - `xout::Vector{Float64}`: Array of x-coordinates of the arc-length re-parameterized curve
+  - `zout::Vector{Float64}`: Array of z-coordinates of the arc-length re-parameterized curve
+  - `ell::Vector{Float64}`: Array of cumulative arc lengths for the input curve
+  - `thgr::Vector{Float64}`: Array of re-parameterized 'theta' values corresponding to equal arc lengths
+  - `thlag::Vector{Float64}`: Array of normalized 'theta' values for the input curve (0 to 1)
 
 # Notes
 
-- Uses Lagrange interpolation for calculating arc length and resampling
-- Ensures uniform spacing in arc length for improved numerical stability
+  - Uses Lagrange interpolation for calculating arc length and resampling
+  - Ensures uniform spacing in arc length for improved numerical stability
 """
 function distribute_to_equal_arc_grid(xin::Vector{Float64}, zin::Vector{Float64}, mtheta::Int)
 
     # Temporary arrays for interpolation and arc-length calculation
     theta_in = zeros(Float64, mtheta) # Normalized input parameter [0, 1)
-    theta_out  = zeros(Float64, mtheta) # New parameter distribution for equal spacing
-    xout  = zeros(Float64, mtheta) # Uniformly spaced R-coordinates
-    zout  = zeros(Float64, mtheta) # Uniformly spaced Z-coordinates
+    theta_out = zeros(Float64, mtheta) # New parameter distribution for equal spacing
+    xout = zeros(Float64, mtheta) # Uniformly spaced R-coordinates
+    zout = zeros(Float64, mtheta) # Uniformly spaced Z-coordinates
 
     # Define initial normalized parameter theta_in
     dt = 1.0 / mtheta
-    theta_in .= range(start=0, length=mtheta, step=dt) # θ ∈ [0, 1)
+    theta_in .= range(; start=0, length=mtheta, step=dt) # θ ∈ [0, 1)
     # we need a closed loop for arc length calculation
     mtheta1 = mtheta + 1
     xin1 = vcat(xin, xin[1])
     zin1 = vcat(zin, zin[1])
     theta_in1 = vcat(theta_in, [1.0])
-    ell   = zeros(Float64, mtheta1) # Cumulative arc length of closed loop
+    ell = zeros(Float64, mtheta1) # Cumulative arc length of closed loop
 
     # Calculate cumulative arc length using numerical integration
     # We use a mid-point derivative approximation to find the path length
     for iw in 2:mtheta1
         # Evaluate derivative at the midpoint of the interval
-        theta = (theta_in1[iw] + theta_in1[iw - 1]) / 2.0
-        
+        theta = (theta_in1[iw] + theta_in1[iw-1]) / 2.0
+
         # Calculate dx/dt and dz/dt using Lagrange interpolation (order 3)
         _, d_xin = lagrange1d(theta_in1, xin1, mtheta1, 3, theta, 1)
         _, d_zin = lagrange1d(theta_in1, zin1, mtheta1, 3, theta, 1)
 
         # Instantaneous speed (ds/dt)
         ds_dt = sqrt(d_xin^2 + d_zin^2)
-        
+
         # Accumulate length: ds = (ds/dt) * dt
-        ell[iw] = ell[iw - 1] + ds_dt * dt
+        ell[iw] = ell[iw-1] + ds_dt * dt
     end
 
     # Re-parameterize based on equal arc-length segments
-    ell_targets = collect(range(0, step=ell[end]/mtheta, length=mtheta)) # [0, Length) for open loop result
+    ell_targets = collect(range(0; step=ell[end]/mtheta, length=mtheta)) # [0, Length) for open loop result
     for i in 2:mtheta
         # Find the value of 'theta_in' that corresponds to the target arc length 's'
         f_th, _ = lagrange1d(ell, theta_in1, mtheta1, 3, ell_targets[i], 0)
@@ -452,6 +461,6 @@ function distribute_to_equal_arc_grid(xin::Vector{Float64}, zin::Vector{Float64}
         xout[i] = f_x
         zout[i] = f_z
     end
-        
+
     return xout, zout, ell, theta_out, theta_in
 end

--- a/test/runtests_vacuum_julia.jl
+++ b/test/runtests_vacuum_julia.jl
@@ -72,9 +72,8 @@ using Interpolations
                 VacuumInput(
                     r=0.05 .+ 0.03 .* cos.(range(0, 2pi, length=16)),
                     z=0.03 .* sin.(range(0, 2pi, length=16)),
-                    delta=zeros(16),
-                    mtheta=16,
-                    mtheta_eq=16
+                    ν=zeros(16),
+                    mtheta=16
                 )
             )
             # Use a "dee" wall shape with parameters that will produce R < 0

--- a/test/runtests_vacuum_julia.jl
+++ b/test/runtests_vacuum_julia.jl
@@ -56,7 +56,7 @@ using Interpolations
                     mtheta=16
                 )
             )
-            
+
             # Test "nowall"
             wall_settings = WallShapeSettings(shape="nowall")
             wall_geo = JPEC.Vacuum.initialize_wall(inputs, plasma_surf, wall_settings)
@@ -68,16 +68,41 @@ using Interpolations
             @test wall_geo.nowall == false
             @test length(wall_geo.x) == 16
             @test !any(isnan, wall_geo.x)
+
+            # Test that wall with R <= 0 throws an error
+            # Create a plasma surface very close to R=0
+            plasma_surf_near_zero = JPEC.Vacuum.initialize_plasma_surface(
+                VacuumInput(
+                    r=0.05 .+ 0.03 .* cos.(range(0, 2pi, length=16)),
+                    z=0.03 .* sin.(range(0, 2pi, length=16)),
+                    delta=zeros(16),
+                    mtheta=16,
+                    mtheta_eq=16
+                )
+            )
+            # Use a "dee" wall shape with parameters that will produce R < 0
+            # Setting cw (offset) to a large negative value will shift the wall left past R=0
+            wall_settings_negative = WallShapeSettings(shape="dee", cw=-1.5, a=0.1)
+            @test_throws ErrorException JPEC.Vacuum.initialize_wall(inputs, plasma_surf_near_zero, wall_settings_negative)
+
+            # Test that conformal wall R-coordinates are clamped by centerstack_min
+            # With a very large 'a' parameter, a conformal wall would naturally go to R < 0,
+            # but it should be clamped to centerstack_min = min(0.1, 0.1 * minimum(x_plasma))
+            wall_settings_large_a = WallShapeSettings(shape="conformal", a=10.0, equal_arc_wall=false)
+            wall_geo_clamped = JPEC.Vacuum.initialize_wall(inputs, plasma_surf_near_zero, wall_settings_large_a)
+            expected_min = min(0.1, 0.1 * minimum(plasma_surf_near_zero.x))
+            @test all(wall_geo_clamped.x .>= expected_min)
+            @test any(wall_geo_clamped.x .<= expected_min + 1e-10)  # At least one point should be at the minimum
         end
 
-        @testset "distribute_to_equal_arc_grid" begin            
+        @testset "distribute_to_equal_arc_grid" begin
             # A simple circle (note the function assumes periodic shapes with open loop endpoints)
             theta = range(0, step=2pi/10, length=10)
             xin_circ = cos.(theta)
             zin_circ = sin.(theta)
             xout_circ, zout_circ, _, _, _ = JPEC.Vacuum.distribute_to_equal_arc_grid(xin_circ, zin_circ, 10)
             # The points should still be on the unit circle
-            @test all(r -> isapprox(r, 1.0, atol=1e-9), sqrt.(xout_circ.^2 + zout_circ.^2))
+            @test all(r -> isapprox(r, 1.0, atol=1e-9), sqrt.(xout_circ .^ 2 + zout_circ .^ 2))
         end
     end
 
@@ -161,11 +186,11 @@ using Interpolations
             mtheta_in = 17
             theta_in = collect(range(0, 1, length=mtheta_in))
             vecin = sin.(2π .* theta_in)
-            
+
             mtheta_out = 33
             vecout = JPEC.Vacuum.interp_to_new_grid(vecin, mtheta_out)
-            
-            theta_out = (0:mtheta_out-1) ./ mtheta_out
+
+            theta_out = (0:(mtheta_out-1)) ./ mtheta_out
             expected_out = sin.(2π .* theta_out)
 
             @test isapprox(vecout, expected_out, atol=1e-2)
@@ -176,7 +201,7 @@ using Interpolations
         end
 
         @testset "periodic_cubic_deriv" begin
-            theta = range(0, 2pi, length=101)[1:end-1]
+            theta = range(0, 2pi, length=101)[1:(end-1)]
             vals = sin.(theta)
             derivs = JPEC.Vacuum.periodic_cubic_deriv(theta, vals)
             @test isapprox(derivs, cos.(theta), atol=1e-3)
@@ -190,7 +215,7 @@ using Interpolations
             @test Z_points == [3, 4, 5, 3, 4, 5]
         end
     end
-    
+
     # ----------------------------------------------------------------------
     @testset "VacuumInternals.jl - Fourier" begin
         @testset "fourier_transform!" begin
@@ -199,9 +224,9 @@ using Interpolations
             gij = [1.0 2.0 3.0 4.0; 5.0 6.0 7.0 8.0; 9.0 10.0 11.0 12.0; 13.0 14.0 15.0 16.0]
             cs = zeros(mtheta, mpert)
             cs[:, 1] .= 1.0 # Simple basis
-            
+
             JPEC.Vacuum.fourier_transform!(gil, gij, cs, 0, 0)
-            
+
             # gil should be the sum of columns of gij
             @test gil[:, 1] == [10.0, 26.0, 42.0, 58.0]
             @test gil[:, 2] == [0.0, 0.0, 0.0, 0.0]
@@ -215,12 +240,12 @@ using Interpolations
             cs = zeros(mtheta, mpert)
             cs[:, 1] .= 1.0
             gll = zeros(mpert, mpert)
-            
+
             JPEC.Vacuum.fourier_inverse_transform!(gll, gil, cs, 0, 0)
-            
+
             # gll[1,1] should be sum(cs[:,1] .* gil[:,1]) * 2pi*dth
             expected = sum([1.0, 2.0, 3.0, 4.0]) * dth * 2pi
-            @test isapprox(gll[1,1], expected)
+            @test isapprox(gll[1, 1], expected)
         end
     end
 
@@ -232,18 +257,18 @@ using Interpolations
             mtheta_eq = 17
             r_eq = 1.7 .+ 0.3 .* cos.(range(0, 2pi, length=mtheta_eq))
             z_eq = 0.3 .* sin.(range(0, 2pi, length=mtheta_eq))
-            
+
             inputs = VacuumInput(
-                r = collect(r_eq),
-                z = collect(z_eq),
-                delta = zeros(mtheta_eq),
-                mlow = 1,
-                mhigh = 2,
-                mpert = 2,
-                n = 1,
-                qa = 2.0,
-                mtheta_eq = mtheta_eq,
-                mtheta = mtheta
+                r=collect(r_eq),
+                z=collect(z_eq),
+                delta=zeros(mtheta_eq),
+                mlow=1,
+                mhigh=2,
+                mpert=2,
+                n=1,
+                qa=2.0,
+                mtheta_eq=mtheta_eq,
+                mtheta=mtheta
             )
             wall_settings = WallShapeSettings(shape="nowall")
 
@@ -265,16 +290,16 @@ using Interpolations
             z_eq = 0.3 .* sin.(range(0, 2pi, length=mtheta_eq))
 
             inputs = VacuumInput(
-                r = collect(r_eq),
-                z = collect(z_eq),
-                delta = zeros(mtheta_eq),
-                mlow = 1,
-                mhigh = 2,
-                mpert = 2,
-                n = 1,
-                qa = 2.0,
-                mtheta_eq = mtheta_eq,
-                mtheta = mtheta
+                r=collect(r_eq),
+                z=collect(z_eq),
+                delta=zeros(mtheta_eq),
+                mlow=1,
+                mhigh=2,
+                mpert=2,
+                n=1,
+                qa=2.0,
+                mtheta_eq=mtheta_eq,
+                mtheta=mtheta
             )
             # Use a conformal wall
             wall_settings = WallShapeSettings(shape="conformal", a=0.5)


### PR DESCRIPTION
Removing x_wall < 0 logic (has_zero_crossing, jbot, jtop, iend, istart), and having it error out if the wall has points less than zero, adding warning if centerstack_min is used, nice cleanup to the Simpson integration