### PR TITLE
(perf): Introduce `AdaptiveArrayPools` package for temporary array recycling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["Matthew Pharr <matthewcpharr@gmail.com>", "Rithik Banerjee <rb3736@c
 version = "0.1.0"
 
 [deps]
+AdaptiveArrayPools = "4f381ef7-9af0-4cbe-99d4-cf36d7b0f233"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -25,6 +26,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+AdaptiveArrayPools = "0.2.0"
 DelimitedFiles = "1.9.1"
 DiffEqCallbacks = "4.9.0"
 Documenter = "1.14.1"

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -455,6 +455,10 @@ function equilibrium_solver(raw_profile::DirectRunInput)
     # Loop over flux surfaces from outermost to innermost, integrating over field lines
     sq_nodes = zeros(Float64, mpsi + 1, 4)
     rzphi_nodes = zeros(Float64, mpsi + 1, mtheta + 1, 4)
+
+    ff_val = zeros(Float64, 4)
+    ff_deriv_val = zeros(Float64, 4)
+
     for ipsi in (mpsi+1):-1:1
         # Integrate along the field line for this surface
         y_out, bfield = direct_fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2)
@@ -477,11 +481,15 @@ function equilibrium_solver(raw_profile::DirectRunInput)
         # Interpolate `ff` onto the uniform `theta` grid for `rzphi`
         for itheta in 1:(mtheta+1)
             theta = theta_nodes[itheta]
-            ff_val = ff_interp(theta)
+
+            # In-place operation to avoid allocations
+            ff_interp(ff_val, theta)
+            ff_deriv(ff_deriv_val, theta)
+
             rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
             rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
             rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
-            rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv(theta)[4]) * y_out[end, 2] * 2π * psio
+            rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
         end
 
         # Store surface-averaged quantities for the `sq` spline

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -61,7 +61,7 @@ the Julia spline implementation.
   - `psio`: total toroidal flux
   - `derivs`: An integer specifying number of derivatives to compute (0, 1, or 2)
 """
-function direct_get_bfield!(
+@with_pool pool function direct_get_bfield!(
     bf_out::DirectBField,
     r::Float64,
     z::Float64,
@@ -91,8 +91,10 @@ function direct_get_bfield!(
     psi_norm = (psio > 1e-12) ? (1.0 - bf_out.psi / psio) : 0.0
     psi_norm = clamp(psi_norm, 0.0, 1.0)
 
-    f_sq = sq_in(psi_norm)
-    f1_sq = sq_in_deriv(psi_norm)
+    f_sq = acquire!(pool, eltype(sq_in.y), n_series(sq_in))
+    f1_sq = acquire!(pool, eltype(sq_in_deriv.parent.y), n_series(sq_in_deriv.parent))
+    sq_in(f_sq, psi_norm)
+    sq_in_deriv(f1_sq, psi_norm)
     bf_out.f = f_sq[1]  # F = R*Bt
     bf_out.f1 = f1_sq[1] # dF/dψ
     bf_out.p = f_sq[2]  # μ0*Pressure

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -422,7 +422,7 @@ robustness.
     including the profile spline (`sq`), the coordinate mapping spline (`rzphi`), and
     the physics quantity spline (`eqfun`).
 """
-function equilibrium_solver(raw_profile::DirectRunInput)
+@with_pool pool function equilibrium_solver(raw_profile::DirectRunInput)
 
     # Shorthand
     equil_params = raw_profile.config
@@ -453,24 +453,29 @@ function equilibrium_solver(raw_profile::DirectRunInput)
     ro, zo, rs1, rs2 = direct_position!(raw_profile)
 
     # Loop over flux surfaces from outermost to innermost, integrating over field lines
-    sq_nodes = zeros(Float64, mpsi + 1, 4)
-    rzphi_nodes = zeros(Float64, mpsi + 1, mtheta + 1, 4)
+    sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)
+    rzphi_nodes = zeros!(pool, Float64, mpsi + 1, mtheta + 1, 4)
 
-    ff_val = zeros(Float64, 4)
-    ff_deriv_val = zeros(Float64, 4)
+    ff_val = zeros!(pool, Float64, 4)
+    ff_deriv_val = zeros!(pool, Float64, 4)
 
     for ipsi in (mpsi+1):-1:1
         # Integrate along the field line for this surface
         y_out, bfield = direct_fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2)
 
+        # checkpoint pool for Float64 slot 
+        checkpoint!(pool, Float64)
+        
         # Fit data into temporary straight fieldline poloidal angle splines
-        ff_x_nodes = y_out[:, 5] ./ y_out[end, 5]
-        ff_fs_nodes = hcat(
-            y_out[:, 3] .^ 2,
-            y_out[:, 1] / (2π) .- ff_x_nodes,
-            bfield.f * (y_out[:, 4] .- ff_x_nodes .* y_out[end, 4]),
-            y_out[:, 2] ./ y_out[end, 2] .- ff_x_nodes
-        )
+        ff_x_nodes = acquire!(pool, Float64, size(y_out, 1))
+        @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
+
+        ff_fs_nodes = acquire!(pool, Float64, size(y_out, 1), 4)
+        @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
+        @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
+        @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])   
+        @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
+
         # Enforce exact endpoint matching for periodic data (removes floating-point noise)
         ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]
 
@@ -497,6 +502,9 @@ function equilibrium_solver(raw_profile::DirectRunInput)
         sq_nodes[ipsi, 2] = bfield.p
         sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
         sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
+
+        # rewind pool for Float64 slot
+        rewind!(pool, Float64)
     end
 
     # Create temporary ProfileSplines for q-profile revision calculation

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -5,7 +5,8 @@ module Equilibrium
 using Printf, OrdinaryDiffEq, DiffEqCallbacks, LinearAlgebra, HDF5
 using TOML
 import FastInterpolations
-using FastInterpolations: cubic_interp, deriv1, deriv2, deriv3, LinearBinary, CubicFit, PeriodicBC, AbstractExtrap, ExtendExtrap, WrapExtrap
+using FastInterpolations: cubic_interp, deriv1, deriv2, deriv3, LinearBinary, CubicFit, PeriodicBC, AbstractExtrap, ExtendExtrap, WrapExtrap, n_series
+using AdaptiveArrayPools
 import StaticArrays: @MMatrix, SVector
 
 # --- Internal Module Structure ---

--- a/src/Equilibrium/ReadEquilibrium.jl
+++ b/src/Equilibrium/ReadEquilibrium.jl
@@ -23,7 +23,7 @@ function _read_1d_gfile_format(lines_block::Vector{String}, num_values::Int)
     safe_len = (length(data_str) ÷ field_width) * field_width
     for i in 1:field_width:safe_len
         num_read >= num_values && break
-        val_str = strip(data_str[i:(i+field_width-1)])
+        val_str = strip(@view(data_str[i:(i+field_width-1)]))
         if !isempty(val_str)
             try
                 push!(parsed_values, parse(Float64, val_str))

--- a/src/ForceFreeStates/FixedBoundaryStability.jl
+++ b/src/ForceFreeStates/FixedBoundaryStability.jl
@@ -61,7 +61,7 @@ can do it post-integration rather than during and don't directly handle file out
 
     # Compute smallest eigenvalue (crit) at current step
     # Use shared hint with LinearBinary() search for O(1) interval lookup during sequential stability evaluation
-    u = unsafe_acquire!(pool, eltype(odet.u_store), size(odet.u_store)[1:3])
+    u = acquire!(pool, eltype(odet.u_store), size(odet.u_store)[1:3])
     psi = odet.psi_store[istep]
     u .= odet.u_store[:, :, :, istep]
     dVdpsi = profiles.dVdpsi_spline(psi; hint=odet.spline_hint)
@@ -101,19 +101,19 @@ construction but may accumulate numerical noise during integration.
 
 ### Arguments
 
-  - `u::Array{ComplexF64, 3}`: Solution matrix at `psi`
+  - `u::AbstractArray{ComplexF64, 3}`: Solution matrix at `psi`
 
 ### Returns
 
   - `crit::Float64`: the computed scaled critical eigenvalue
   - `nonherm::Bool`: true if W⁻¹ was non-Hermitian beyond tolerance (> 1e-3)
 """
-@with_pool pool function compute_smallest_eigenvalue(u::Array{ComplexF64,3})
+@with_pool pool function compute_smallest_eigenvalue(u::AbstractArray{ComplexF64,3})
 
     # Compute inverse plasma response matrix W⁻¹ = U₁ * U₂⁻¹
     # The following is in-place operation equivalent to wp_inverse = u[:, :, 1] / u[:, :, 2]
-    wp_inverse = unsafe_acquire!(pool, ComplexF64, size(u, 1), size(u, 2))
-    U2_tmp = unsafe_similar!(pool, wp_inverse)
+    wp_inverse = acquire!(pool, ComplexF64, size(u, 1), size(u, 2))
+    U2_tmp = similar!(pool, wp_inverse)
     wp_inverse .= @view u[:, :, 1]
     U2_tmp .= @view u[:, :, 2]
     rdiv!(wp_inverse, lu!(U2_tmp))
@@ -126,9 +126,9 @@ construction but may accumulate numerical noise during integration.
     # Check to make sure W is at least close to Hermitian before enforcing it
 
     # Compute adjoint in-place to avoid allocations
-    adjoint_wp_inverse = unsafe_similar!(pool, wp_inverse)
-    tmp_mat1 = unsafe_similar!(pool, wp_inverse)
-    tmp_mat2 = unsafe_similar!(pool, wp_inverse)
+    adjoint_wp_inverse = similar!(pool, wp_inverse)
+    tmp_mat1 = similar!(pool, wp_inverse)
+    tmp_mat2 = similar!(pool, wp_inverse)
     adjoint!(adjoint_wp_inverse, wp_inverse)
     @. tmp_mat1 = 0.5 * (wp_inverse + adjoint_wp_inverse)
     @. tmp_mat2 = 0.5 * (wp_inverse - adjoint_wp_inverse)

--- a/src/ForceFreeStates/FixedBoundaryStability.jl
+++ b/src/ForceFreeStates/FixedBoundaryStability.jl
@@ -108,10 +108,15 @@ construction but may accumulate numerical noise during integration.
   - `crit::Float64`: the computed scaled critical eigenvalue
   - `nonherm::Bool`: true if W⁻¹ was non-Hermitian beyond tolerance (> 1e-3)
 """
-function compute_smallest_eigenvalue(u::Array{ComplexF64,3})
+@with_pool pool function compute_smallest_eigenvalue(u::Array{ComplexF64,3})
 
     # Compute inverse plasma response matrix W⁻¹ = U₁ * U₂⁻¹
-    @views wp_inverse = u[:, :, 1] / u[:, :, 2]
+    # The following is in-place operation equivalent to wp_inverse = u[:, :, 1] / u[:, :, 2]
+    wp_inverse = unsafe_acquire!(pool, ComplexF64, size(u, 1), size(u, 2))
+    U2_tmp = unsafe_similar!(pool, wp_inverse)
+    wp_inverse .= @view u[:, :, 1]
+    U2_tmp .= @view u[:, :, 2]
+    rdiv!(wp_inverse, lu!(U2_tmp))
 
     # TODO: This section not be necessary since W should be Hermitian by construction.
     # This likely just removes any numerical noise during integration
@@ -119,7 +124,16 @@ function compute_smallest_eigenvalue(u::Array{ComplexF64,3})
     # by ignoring the lower triangle (by default, can ignore upper using `uplo=:L`), which will
     # NOT produce identical results to taking the Hermitian part as done here unless is exactly Hermitian.
     # Check to make sure W is at least close to Hermitian before enforcing it
-    nonherm_error = norm(0.5 * (wp_inverse - adjoint(wp_inverse))) / norm(0.5 * (wp_inverse + adjoint(wp_inverse)))
+
+    # Compute adjoint in-place to avoid allocations
+    adjoint_wp_inverse = unsafe_similar!(pool, wp_inverse)
+    tmp_mat1 = unsafe_similar!(pool, wp_inverse)
+    tmp_mat2 = unsafe_similar!(pool, wp_inverse)
+    adjoint!(adjoint_wp_inverse, wp_inverse)
+    @. tmp_mat1 = 0.5 * (wp_inverse + adjoint_wp_inverse)
+    @. tmp_mat2 = 0.5 * (wp_inverse - adjoint_wp_inverse)
+
+    nonherm_error = norm(tmp_mat2) / norm(tmp_mat1)
     nonherm = nonherm_error > 1e-3
 
     # Enforce that W is Hermitian

--- a/src/ForceFreeStates/FixedBoundaryStability.jl
+++ b/src/ForceFreeStates/FixedBoundaryStability.jl
@@ -57,12 +57,13 @@ can do it post-integration rather than during and don't directly handle file out
   - `zero_cross::Bool`: True if a physical zero crossing was detected
   - `nonherm::Bool`: True if W⁻¹ was non-Hermitian beyond tolerance
 """
-function check_for_zero_crossings!(odet::OdeState, profiles::Equilibrium.ProfileSplines, istep::Int)
+@with_pool pool function check_for_zero_crossings!(odet::OdeState, profiles::Equilibrium.ProfileSplines, istep::Int)
 
     # Compute smallest eigenvalue (crit) at current step
     # Use shared hint with LinearBinary() search for O(1) interval lookup during sequential stability evaluation
+    u = unsafe_acquire!(pool, eltype(odet.u_store), size(odet.u_store)[1:3])
     psi = odet.psi_store[istep]
-    u = odet.u_store[:, :, :, istep]
+    u .= odet.u_store[:, :, :, istep]
     dVdpsi = profiles.dVdpsi_spline(psi; hint=odet.spline_hint)
     crit_val, nonherm = compute_smallest_eigenvalue(u)
     odet.crit_store[istep] = crit_val * dVdpsi^2

--- a/src/ForceFreeStates/ForceFreeStates.jl
+++ b/src/ForceFreeStates/ForceFreeStates.jl
@@ -10,6 +10,7 @@ using HDF5
 using JLD2
 using FastInterpolations
 using FastInterpolations: cubic_interp, deriv1, PeriodicBC, LinearBinary
+using AdaptiveArrayPools
 
 import ..Equilibrium
 import ..Utilities

--- a/src/ForceFreeStates/ForceFreeStatesStructs.jl
+++ b/src/ForceFreeStates/ForceFreeStatesStructs.jl
@@ -397,17 +397,6 @@ and a small set of temporary matrices and factors used to compute singular-layer
   - `fixfac::Array{ComplexF64,3}` - Fix-up factors for Gaussian reduction with shape
     `(numpert_total, numpert_total, numunorms_init)`.
   - `fixstep::Vector{Int64}` - Step indices (psi step positions) at which normalization/fixups were performed (length `numunorms_init`).
-  - Temporary workspaces used during integration calculations:
-
-      + `amat::Vector{ComplexF64}` - Flattened A matrix (length `numpert_total^2`)
-      + `bmat::Vector{ComplexF64}` - Flattened B matrix (length `numpert_total^2`)
-      + `cmat::Vector{ComplexF64}` - Flattened C matrix (length `numpert_total^2`)
-      + `fmat_lower::Vector{ComplexF64}` - Lower-triangle factor of F (length `numpert_total^2`)
-      + `kmat::Vector{ComplexF64}` - Flattened K matrix (length `numpert_total^2`)
-      + `gmat::Vector{ComplexF64}` - Flattened G matrix (length `numpert_total^2`)
-      + `tmp::Matrix{ComplexF64}` - Workspace matrix for EL derivative calculations with shape `(numpert_total, numpert_total)`.
-      + `Afact::Union{Cholesky{ComplexF64, Matrix{ComplexF64}}, Nothing}` - Cholesky factor
-      + `singfac_vec::Vector{Float64}` - Vector of m-nq factors
 """
 @kwdef mutable struct OdeState
     # Initialization parameters
@@ -451,17 +440,6 @@ and a small set of temporary matrices and factors used to compute singular-layer
     zeroed_idx::Vector{Vector{Int}} = [Int[] for _ in 1:numunorms_init]
     fixfac::Array{ComplexF64,3} = zeros(ComplexF64, numpert_total, numpert_total, numunorms_init)
     fixstep::Vector{Int64} = zeros(Int64, numunorms_init)
-
-    # Temporary matrices for sing_der calculations
-    amat::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    bmat::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    cmat::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    fmat_lower::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    kmat::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    gmat::Vector{ComplexF64} = Vector{ComplexF64}(undef, numpert_total^2)
-    tmp::Matrix{ComplexF64} = Matrix{ComplexF64}(undef, numpert_total, numpert_total)
-    Afact::Cholesky{ComplexF64,Matrix{ComplexF64}} = cholesky(Matrix{ComplexF64}(I, numpert_total, numpert_total))
-    singfac_vec::Vector{Float64} = Vector{Float64}(undef, numpert_total)
 
     # Shared hint for CubicInterpolant interval search optimization during ODE integration
     # All splines evaluated at the same psi can share this hint for O(1) interval lookups

--- a/src/ForceFreeStates/Free.jl
+++ b/src/ForceFreeStates/Free.jl
@@ -26,7 +26,7 @@ and data dumping.
 
     # Compute plasma response matrix W = U₂ * U₁⁻¹
     if ctrl.ode_flag
-        @views wp = (odet.u[:, :, 2] / odet.u[:, :, 1]) ./ equil.psio^2
+        @views wp .= (odet.u[:, :, 2] / odet.u[:, :, 1]) ./ equil.psio^2
     end
 
     # Compute vacuum response matrix
@@ -89,8 +89,10 @@ and data dumping.
 
     # Compute plasma and vacuum contributions.
     # wpt = wt' * wp * wt  ; wvt = wt' * wv * wt
-    wpt .= adjoint(vac.wt) * (wp * vac.wt)
-    wvt .= adjoint(vac.wt) * (vac.wv * vac.wt)
+    mul!(tmp_mat, wp, vac.wt)
+    mul!(wpt, adjoint(vac.wt), tmp_mat)
+    mul!(tmp_mat, vac.wv, vac.wt)
+    mul!(wvt, adjoint(vac.wt), tmp_mat)
     for ipert in 1:intr.numpert_total
         vac.ep[ipert] = wpt[ipert, ipert]
         vac.ev[ipert] = wvt[ipert, ipert]

--- a/src/ForceFreeStates/Free.jl
+++ b/src/ForceFreeStates/Free.jl
@@ -7,14 +7,19 @@ modifies `odet` in place to normalize the eigenfunctions stored in `u_store` and
 and returns a `VacuumData` struct containing the data needed for perturbed equilibrium calculations
 and data dumping.
 """
-function free_run!(odet::OdeState, ctrl::ForceFreeStatesControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::ForceFreeStatesInternal)
+@with_pool pool function free_run!(odet::OdeState, ctrl::ForceFreeStatesControl, equil::Equilibrium.PlasmaEquilibrium, ffit::FourFitVars, intr::ForceFreeStatesInternal)
 
     # Initializations and allocations
     vac = VacuumData(ctrl.mthvac, intr.mpert, intr.numpert_total)
-    etemp = zeros(ComplexF64, intr.numpert_total)
-    wp = zeros(ComplexF64, intr.numpert_total, intr.numpert_total)
-    wpt = zeros(ComplexF64, intr.numpert_total, intr.numpert_total)
-    wvt = zeros(ComplexF64, intr.numpert_total, intr.numpert_total)
+
+    Npert = intr.numpert_total
+
+    etemp = zeros!(pool, ComplexF64, Npert)
+    wp = zeros!(pool, ComplexF64, Npert, Npert)
+    wpt = zeros!(pool, ComplexF64, Npert, Npert)
+    wvt = zeros!(pool, ComplexF64, Npert, Npert)
+
+    tmp_mat = zeros!(pool, ComplexF64, Npert, Npert)
 
     # Evaluate dV/dpsi at the plasma edge
     dV_dpsi = equil.profiles.dVdpsi_spline(intr.psilim)
@@ -94,14 +99,14 @@ function free_run!(odet::OdeState, ctrl::ForceFreeStatesControl, equil::Equilibr
     # Normalize eigenvectors based on scaled wt
     coeffs = odet.u[:, :, 1, end] \ (vac.wt .* (2π * equil.psio * 1e-3))
     @views for istep in 1:odet.step
-        mul!(odet.tmp, odet.u_store[:, :, 1, istep], coeffs)
-        odet.u_store[:, :, 1, istep] .= odet.tmp
-        mul!(odet.tmp, odet.u_store[:, :, 2, istep], coeffs)
-        odet.u_store[:, :, 2, istep] .= odet.tmp
-        mul!(odet.tmp, odet.ud_store[:, :, 1, istep], coeffs)
-        odet.ud_store[:, :, 1, istep] .= odet.tmp
-        mul!(odet.tmp, odet.ud_store[:, :, 2, istep], coeffs)
-        odet.ud_store[:, :, 2, istep] .= odet.tmp
+        mul!(tmp_mat, odet.u_store[:, :, 1, istep], coeffs)
+        odet.u_store[:, :, 1, istep] .= tmp_mat
+        mul!(tmp_mat, odet.u_store[:, :, 2, istep], coeffs)
+        odet.u_store[:, :, 2, istep] .= tmp_mat
+        mul!(tmp_mat, odet.ud_store[:, :, 1, istep], coeffs)
+        odet.ud_store[:, :, 1, istep] .= tmp_mat
+        mul!(tmp_mat, odet.ud_store[:, :, 2, istep], coeffs)
+        odet.ud_store[:, :, 2, istep] .= tmp_mat
     end
 
     # Write energies to screen

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -760,7 +760,6 @@ Implement kin_flag functionality
     gmat = similar!(pool, amat)
     tmp_mat = similar!(pool, amat)
 
-
     fill!(tmp_mat, zero(ComplexF64))
     u1 = @view(u[:, :, 1])
     u2 = @view(u[:, :, 2])

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -591,7 +591,7 @@ end
 
     fill!(out, zero(ComplexF64))
     # main computation
-    tmp = unsafe_acquire!(pool, ComplexF64, size(a, 1))
+    tmp = acquire!(pool, ComplexF64, size(a, 1))
     for i in 1:n
         for j in 1:2
             @views mul!(tmp, a[:, 1:m, j], b[:, i, 1])

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -591,13 +591,13 @@ end
 
     fill!(out, zero(ComplexF64))
     # main computation
-    tmp = unsafe_zeros!(pool, ComplexF64, size(a, 1))
+    tmp = unsafe_acquire!(pool, ComplexF64, size(a, 1))
     for i in 1:n
         for j in 1:2
             @views mul!(tmp, a[:, 1:m, j], b[:, i, 1])
-            out[:, i, j] .+= tmp
+            @views out[:, i, j] .+= tmp
             @views mul!(tmp, a[:, (m+1):(2*m), j], b[:, i, 2])
-            out[:, i, j] .+= tmp
+            @views out[:, i, j] .+= tmp
         end
     end
 

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -522,7 +522,7 @@ See equation 47 in the Glasser 2016 DCON paper. Identical to the Fortran
   - `power::Vector{ComplexF64}`: α values for all modes (0 for nonresonant)
   - `k::Int`: The current order in the power series expansion
 """
-function solve_higher_order_vmat!(
+@with_pool pool function solve_higher_order_vmat!(
     vmat::Array{ComplexF64,4},
     mmat::Array{ComplexF64,4},
     m0mat::Matrix{ComplexF64},
@@ -536,9 +536,11 @@ function solve_higher_order_vmat!(
     k::Int
 )
 
+    tmp_arr = zeros!(pool, ComplexF64, size(vmat)[1:3])
     # Compute ∑Mₗvₖ₋ₗ
     for l in 1:k
-        vmat[:, :, :, k+1] .+= sing_matmul(mmat[:, :, :, l+1], vmat[:, :, :, k-l+1])
+        @views sing_matmul!(tmp_arr, mmat[:, :, :, l+1], vmat[:, :, :, k-l+1])
+        vmat[:, :, :, k+1] .+= tmp_arr
     end
     for isol in 1:(2*intr.numpert_total)
         for i in eachindex(r1) # go block by block?
@@ -566,14 +568,19 @@ Identical to the Fortran `sing_matmul` subroutine.
 
 ### Arguments
 
-  - `a::Array{ComplexF64,3}`: shape (mpert, 2 * mpert, 2)
-  - `b::Array{ComplexF64,3}`: shape (mmpert, 2 * mpert, 2)
+  - `a::AbstractArray{ComplexF64,3}`: shape (mpert, 2 * mpert, 2)
+  - `b::AbstractArray{ComplexF64,3}`: shape (mmpert, 2 * mpert, 2)
 
 ## Returns
 
   - `c::Array{ComplexF64,3}`: shape (mpert, 2 * mpert, 2)
 """
-function sing_matmul(a::Array{ComplexF64,3}, b::Array{ComplexF64,3})
+function sing_matmul(a::AbstractArray{ComplexF64,3}, b::AbstractArray{ComplexF64,3})
+    c = zeros(ComplexF64, size(a, 1), size(b, 2), 2)
+    return sing_matmul!(c, a, b)
+end
+
+@with_pool pool function sing_matmul!(out::AbstractArray{ComplexF64,3}, a::AbstractArray{ComplexF64,3}, b::AbstractArray{ComplexF64,3})
     m = size(b, 1)
     n = size(b, 2)
 
@@ -582,20 +589,19 @@ function sing_matmul(a::Array{ComplexF64,3}, b::Array{ComplexF64,3})
         error("Sing_matmul: size(a,2) = $(size(a,2)) != 2*size(b,1) = $(2*m)")
     end
 
-    c = zeros(ComplexF64, size(a, 1), n, 2)
-
+    fill!(out, zero(ComplexF64))
     # main computation
-    tmp = zeros(ComplexF64, size(a, 1))
+    tmp = unsafe_zeros!(pool, ComplexF64, size(a, 1))
     for i in 1:n
         for j in 1:2
             @views mul!(tmp, a[:, 1:m, j], b[:, i, 1])
-            @views c[:, i, j] .+= tmp
+            out[:, i, j] .+= tmp
             @views mul!(tmp, a[:, (m+1):(2*m), j], b[:, i, 2])
-            @views c[:, i, j] .+= tmp
+            out[:, i, j] .+= tmp
         end
     end
 
-    return c
+    return out
 end
 
 """

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -246,7 +246,7 @@ Better way to unpack the cubic splines
 Rename variables to be more intuitive? I don't like ff - maybe f and f_fact instead of f_lower
 Add a spline for F directly instead of the lower triangular factorization to avoid complexity?
 """
-function compute_sing_mmat!(mmat::Array{ComplexF64,4}, singp::SingType, ctrl::ForceFreeStatesControl, profiles::Equilibrium.ProfileSplines, ffit::FourFitVars, intr::ForceFreeStatesInternal)
+@with_pool pool function compute_sing_mmat!(mmat::Array{ComplexF64,4}, singp::SingType, ctrl::ForceFreeStatesControl, profiles::Equilibrium.ProfileSplines, ffit::FourFitVars, intr::ForceFreeStatesInternal)
 
     q_spline = profiles.q_spline
     q_d1 = profiles.q_deriv
@@ -254,17 +254,17 @@ function compute_sing_mmat!(mmat::Array{ComplexF64,4}, singp::SingType, ctrl::Fo
     q_d3 = deriv3(q_spline)
 
     # Initial allocations
-    singfac = zeros(Float64, intr.numpert_total, 4)
-    f_lower_interp = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    g_interp = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    k_interp = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    f_lower = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    f0_lower = zeros(ComplexF64, intr.numpert_total, intr.numpert_total)
-    ff_lower = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    g_lower = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    k = zeros(ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    v = zeros(ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2)
-    x = zeros(ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2, ctrl.sing_order + 1)
+    singfac = zeros!(pool, Float64, intr.numpert_total, 4)
+    f_lower_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
+    g_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
+    k_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
+    f_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
+    f0_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total)
+    ff_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
+    g_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
+    k = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
+    v = zeros!(pool, ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2)
+    x = zeros!(pool, ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2, ctrl.sing_order + 1)
 
     # Evaluate q spline and its derivatives
     q = (q_spline(singp.psifac),

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -550,18 +550,21 @@ See equation 47 in the Glasser 2016 DCON paper. Identical to the Fortran
         @views sing_matmul!(tmp_arr, mmat[:, :, :, l+1], vmat[:, :, :, k-l+1])
         vmat[:, :, :, k+1] .+= tmp_arr
     end
+
+    a = zeros!(pool, ComplexF64, 2, 2)
     for isol in 1:(2*intr.numpert_total)
         for i in eachindex(r1) # go block by block?
             # a = M₀ - (α + k/2)I = ∑Mₗvₖ₋ₗ (for multi-n 2D, we make a the ith block fo M₀)
-            m0mat_block = m0mat[(2*(i-1)+1):(2*i), (2*(i-1)+1):(2*i)]
-            a = copy(m0mat_block)
+            @views m0mat_block = m0mat[(2*(i-1)+1):(2*i), (2*(i-1)+1):(2*i)]
+            a .= m0mat_block
             a[1, 1] -= k / 2.0 + power[isol]
             a[2, 2] -= k / 2.0 + power[isol]
             det = a[1, 1] * a[2, 2] - a[1, 2] * a[2, 1]
             # Solve the resonant indices
-            x = -vmat[r1[i], isol, :, k+1]
-            vmat[r1[i], isol, 1, k+1] = (a[2, 2] * x[1] - a[1, 2] * x[2]) / det
-            vmat[r1[i], isol, 2, k+1] = (a[1, 1] * x[2] - a[2, 1] * x[1]) / det
+            x1 = -vmat[r1[i], isol, 1, k+1]
+            x2 = -vmat[r1[i], isol, 2, k+1]
+            vmat[r1[i], isol, 1, k+1] = (a[2, 2] * x1 - a[1, 2] * x2) / det
+            vmat[r1[i], isol, 2, k+1] = (a[1, 1] * x2 - a[2, 1] * x1) / det
         end
         # Solve the non-resonant indices (the eigenvalue α = 0, so M₀v = 0 (null space))
         vmat[n1, isol, :, k+1] ./= (power[isol] + k / 2.0)

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -734,7 +734,7 @@ more simplistic code with similar performance.
 
 Implement kin_flag functionality
 """
-function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
+@with_pool pool function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
     params::Tuple{ForceFreeStatesControl,Equilibrium.PlasmaEquilibrium,
         FourFitVars,ForceFreeStatesInternal,OdeState,IntegrationChunk},
     psieval::Float64)
@@ -742,7 +742,22 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
     # Unpack structs and initialize
     # note the two items not used here are needed in the integrator params for use in the integrator_callbackcallback
     _, equil, ffit, intr, odet, _ = params
-    fill!(odet.tmp, 0)
+
+    # Allocate temporary arrays from the pool
+    Npert = intr.numpert_total
+
+    singfac_vec = acquire!(pool, Float64, Npert)
+
+    amat = acquire!(pool, ComplexF64, Npert, Npert) 
+    bmat = similar!(pool, amat) 
+    cmat = similar!(pool, amat) 
+    fmat_lower = similar!(pool, amat)
+    kmat = similar!(pool, amat)
+    gmat = similar!(pool, amat)
+    tmp_mat = similar!(pool, amat)
+
+
+    fill!(tmp_mat, zero(ComplexF64))
     u1 = @view(u[:, :, 1])
     u2 = @view(u[:, :, 2])
     du1 = @view(du[:, :, 1])
@@ -751,37 +766,27 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
     # Compute singfac = 1 / (m - nq)
     # Use shared hint with LinearBinary() search for O(1) interval lookup during sequential ODE integration
     odet.q = equil.profiles.q_spline(psieval; hint=odet.spline_hint)
-    odet.singfac_vec .= vec(1.0 ./ ((intr.mlow:intr.mhigh) .- odet.q .* (intr.nlow:intr.nhigh)'))
+    @. singfac_vec = 1.0 / ((intr.mlow:intr.mhigh) - odet.q * (intr.nlow:intr.nhigh)')
 
     # kinetic stuff - skip for now
     if false #(TODO: kin_flag)
         error("kin_flag not implemented yet")
     else
         # Evaluate matrix splines at the current psi value using shared hint
-        ffit.amats(vec(ffit._mat_out), psieval; hint=ffit._hint)
-        amat = ffit._mat_out
+        ffit.amats(vec(amat), psieval; hint=ffit._hint)
+        ffit.bmats(vec(bmat), psieval; hint=ffit._hint)
+        ffit.cmats(vec(cmat), psieval; hint=ffit._hint)
+        ffit.fmats_lower(vec(fmat_lower), psieval; hint=ffit._hint)
+        ffit.kmats(vec(kmat), psieval; hint=ffit._hint)
+        ffit.gmats(vec(gmat), psieval; hint=ffit._hint)
 
-        # Use odet temporary buffers for subsequent matrices to avoid overwriting amat
-        ffit.bmats(odet.bmat, psieval; hint=ffit._hint)
-        bmat = reshape(odet.bmat, intr.numpert_total, intr.numpert_total)
+        # Solve bmat = A⁻¹ * bmat, cmat = A⁻¹ * cmat in-place via Cholesky
+        # Equivalent to: Afact = cholesky!(Hermitian(amat)); ldiv!(Afact, bmat); ldiv!(Afact, cmat)
+        # but calls LAPACK directly to avoid Hermitian/Cholesky wrapper allocations in this hot loop
+        LAPACK.potrf!('U', amat)
+        LAPACK.potrs!('U', amat, bmat)
+        LAPACK.potrs!('U', amat, cmat)
 
-        ffit.cmats(odet.cmat, psieval; hint=ffit._hint)
-        cmat = reshape(odet.cmat, intr.numpert_total, intr.numpert_total)
-
-        ffit.fmats_lower(odet.fmat_lower, psieval; hint=ffit._hint)
-        fmat_lower = reshape(odet.fmat_lower, intr.numpert_total, intr.numpert_total)
-
-        ffit.kmats(odet.kmat, psieval; hint=ffit._hint)
-        kmat = reshape(odet.kmat, intr.numpert_total, intr.numpert_total)
-
-        ffit.gmats(odet.gmat, psieval; hint=ffit._hint)
-        gmat = reshape(odet.gmat, intr.numpert_total, intr.numpert_total)
-
-        odet.Afact = cholesky!(Hermitian(amat))
-        # bmat = A⁻¹ * bmat
-        ldiv!(odet.Afact, bmat)
-        # cmat = A⁻¹ * cmat
-        ldiv!(odet.Afact, cmat)
     end
 
     # Compute du
@@ -790,25 +795,25 @@ function sing_der!(du::Array{ComplexF64,3}, u::Array{ComplexF64,3},
     else
         # See equations 22-24 in Glasser 2016 DCON paper for derivation
         # du[1] = - F̄⁻¹ * K̄ * u[1] + F̄⁻¹ * Q⁻¹ * u[2]
-        du1 .= u2 .* odet.singfac_vec
-        mul!(odet.tmp, kmat, u1)
-        du1 .-= odet.tmp
+        du1 .= u2 .* singfac_vec
+        mul!(tmp_mat, kmat, u1)
+        du1 .-= tmp_mat
         ldiv!(LowerTriangular(fmat_lower), du1)
         ldiv!(UpperTriangular(fmat_lower'), du1)
         # du[2] = G * u[1] + K̄^† * du[1] = G * u[1] - K̄^† * F̄⁻¹ * K̄ * u[1] + K̄^† * F̄⁻¹ * Q⁻¹ * u[2]
-        mul!(odet.tmp, gmat, u1)
-        du2 .= odet.tmp
-        mul!(odet.tmp, adjoint(kmat), du1)
-        du2 .+= odet.tmp
+        mul!(tmp_mat, gmat, u1)
+        du2 .= tmp_mat
+        mul!(tmp_mat, adjoint(kmat), du1)
+        du2 .+= tmp_mat
         # du[1] = - Q⁻¹ * F̄⁻¹ * K̄ * u[1] + Q⁻¹ * F̄⁻¹ * Q⁻¹ * u[2]
-        du1 .*= odet.singfac_vec
+        du1 .*= singfac_vec
     end
 
     # ud[1] = Ξ'_Ψ
     @views odet.ud[:, :, 1] .= du1
     # ud[2] = Ξ_s = - A⁻¹(B * Ξ'_Ψ - C * Ξ_Ψ), eq. 18 of Glasser 2016
-    mul!(odet.tmp, bmat, du1)
-    odet.ud[:, :, 2] .= .-odet.tmp
-    mul!(odet.tmp, cmat, u1)
-    @views odet.ud[:, :, 2] .-= odet.tmp
+    mul!(tmp_mat, bmat, du1)
+    odet.ud[:, :, 2] .= .-tmp_mat
+    mul!(tmp_mat, cmat, u1)
+    @views odet.ud[:, :, 2] .-= tmp_mat
 end

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -751,9 +751,9 @@ Implement kin_flag functionality
 
     singfac_vec = acquire!(pool, Float64, Npert)
 
-    amat = acquire!(pool, ComplexF64, Npert, Npert) 
-    bmat = similar!(pool, amat) 
-    cmat = similar!(pool, amat) 
+    amat = acquire!(pool, ComplexF64, Npert, Npert)
+    bmat = similar!(pool, amat)
+    cmat = similar!(pool, amat)
     fmat_lower = similar!(pool, amat)
     kmat = similar!(pool, amat)
     gmat = similar!(pool, amat)
@@ -769,7 +769,7 @@ Implement kin_flag functionality
     # Compute singfac = 1 / (m - nq)
     # Use shared hint with LinearBinary() search for O(1) interval lookup during sequential ODE integration
     odet.q = equil.profiles.q_spline(psieval; hint=odet.spline_hint)
-    @. singfac_vec = 1.0 / ((intr.mlow:intr.mhigh) - odet.q * (intr.nlow:intr.nhigh)')
+    singfac_vec .= vec(1.0 ./ ((intr.mlow:intr.mhigh) .- odet.q .* (intr.nlow:intr.nhigh)'))
 
     # kinetic stuff - skip for now
     if false #(TODO: kin_flag)

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -254,17 +254,20 @@ Add a spline for F directly instead of the lower triangular factorization to avo
     q_d3 = deriv3(q_spline)
 
     # Initial allocations
-    singfac = zeros!(pool, Float64, intr.numpert_total, 4)
-    f_lower_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    g_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    k_interp = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, 4)
-    f_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    f0_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total)
-    ff_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    g_lower = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    k = zeros!(pool, ComplexF64, intr.numpert_total, intr.numpert_total, ctrl.sing_order + 1)
-    v = zeros!(pool, ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2)
-    x = zeros!(pool, ComplexF64, intr.numpert_total, 2 * intr.numpert_total, 2, ctrl.sing_order + 1)
+    Npert = intr.numpert_total
+
+    singfac = zeros!(pool, Float64, Npert, 4)
+    f_lower_interp = zeros!(pool, ComplexF64, Npert, Npert, 4)
+    g_interp = zeros!(pool, ComplexF64, Npert, Npert, 4)
+    k_interp = zeros!(pool, ComplexF64, Npert, Npert, 4)
+    f_lower = zeros!(pool, ComplexF64, Npert, Npert, ctrl.sing_order + 1)
+    f0_lower = zeros!(pool, ComplexF64, Npert, Npert)
+    ff_lower = zeros!(pool, ComplexF64, Npert, Npert, ctrl.sing_order + 1)
+    g_lower = zeros!(pool, ComplexF64, Npert, Npert, ctrl.sing_order + 1)
+    k = zeros!(pool, ComplexF64, Npert, Npert, ctrl.sing_order + 1)
+    v = zeros!(pool, ComplexF64, Npert, 2 * Npert, 2)
+    x = zeros!(pool, ComplexF64, Npert, 2 * Npert, 2, ctrl.sing_order + 1)
+    tmp_vec = acquire!(pool, ComplexF64, Npert)
 
     # Evaluate q spline and its derivatives
     q = (q_spline(singp.psifac),
@@ -451,7 +454,8 @@ Add a spline for F directly instead of the lower triangular factorization to avo
     # Solve the Taylor expansion according to F * x¹ = v² - K v¹ at each order
     # 0ᵗʰ order: x¹₀ = F⁻¹(v² - K v¹)
     for isol in 1:(2*intr.numpert_total)
-        @views x[:, isol, 1, 1] .= v[:, isol, 2] .- k[:, :, 1] * v[:, isol, 1]
+        @views mul!(tmp_vec, k[:, :, 1], v[:, isol, 1])
+        @views x[:, isol, 1, 1] .= v[:, isol, 2] .- tmp_vec
     end
     @views x[:, :, 1, 1] = UpperTriangular(f0_lower') \ (LowerTriangular(f0_lower) \ x[:, :, 1, 1])
 
@@ -459,9 +463,11 @@ Add a spline for F directly instead of the lower triangular factorization to avo
     for i in 1:ctrl.sing_order
         for isol in 1:(2*intr.numpert_total)
             for j in 1:i
-                @views x[:, isol, 1, i+1] .-= Hermitian(ff_lower[:, :, j+1], :L) * x[:, isol, 1, i-j+1]
+                @views mul!(tmp_vec, Hermitian(ff_lower[:, :, j+1], :L), x[:, isol, 1, i-j+1])
+                @views x[:, isol, 1, i+1] .-= tmp_vec
             end
-            @views x[:, isol, 1, i+1] .-= k[:, :, i+1] * v[:, isol, 1]
+            @views mul!(tmp_vec, k[:, :, i+1], v[:, isol, 1])
+            @views x[:, isol, 1, i+1] .-= tmp_vec
         end
         @views x[:, :, 1, i+1] = UpperTriangular(f0_lower') \ (LowerTriangular(f0_lower) \ x[:, :, 1, i+1])
     end
@@ -470,9 +476,11 @@ Add a spline for F directly instead of the lower triangular factorization to avo
     for i in 0:ctrl.sing_order
         for isol in 1:(2*intr.numpert_total)
             for j in 0:i
-                @views x[:, isol, 2, i+1] .+= adjoint(k[:, :, j+1]) * x[:, isol, 1, i-j+1]
+                @views mul!(tmp_vec, adjoint(k[:, :, j+1]), x[:, isol, 1, i-j+1])
+                @views x[:, isol, 2, i+1] .+= tmp_vec
             end
-            @views x[:, isol, 2, i+1] .+= Hermitian(g_lower[:, :, i+1], :L) * v[:, isol, 1]
+            @views mul!(tmp_vec, Hermitian(g_lower[:, :, i+1], :L), v[:, isol, 1])
+            @views x[:, isol, 2, i+1] .+= tmp_vec
         end
     end
 

--- a/src/ForceFreeStates/Sing.jl
+++ b/src/ForceFreeStates/Sing.jl
@@ -750,6 +750,7 @@ Implement kin_flag functionality
     Npert = intr.numpert_total
 
     singfac_vec = acquire!(pool, Float64, Npert)
+    singfac_mat = reshape(singfac_vec, intr.mpert, intr.npert)
 
     amat = acquire!(pool, ComplexF64, Npert, Npert)
     bmat = similar!(pool, amat)
@@ -769,7 +770,7 @@ Implement kin_flag functionality
     # Compute singfac = 1 / (m - nq)
     # Use shared hint with LinearBinary() search for O(1) interval lookup during sequential ODE integration
     odet.q = equil.profiles.q_spline(psieval; hint=odet.spline_hint)
-    singfac_vec .= vec(1.0 ./ ((intr.mlow:intr.mhigh) .- odet.q .* (intr.nlow:intr.nhigh)'))
+    singfac_mat .= 1.0 ./ ((intr.mlow:intr.mhigh) .- odet.q .* (intr.nlow:intr.nhigh)')
 
     # kinetic stuff - skip for now
     if false #(TODO: kin_flag)

--- a/src/JPEC.jl
+++ b/src/JPEC.jl
@@ -33,6 +33,7 @@ using HDF5
 # Import FastInterpolations functions and types needed in main
 import FastInterpolations: cubic_interp, CubicFit, ExtendExtrap
 
+import AdaptiveArrayPools: @with_pool
 
 # Import ForceFreeStates types and functions needed for main
 using .ForceFreeStates: ForceFreeStatesInternal, ForceFreeStatesControl, DebugSettings, VacuumData, OdeState

--- a/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
@@ -5,6 +5,7 @@ using HDF5
 using Printf
 using LinearAlgebra
 using Statistics
+using AdaptiveArrayPools
 
 # Import parent modules
 import ..Equilibrium

--- a/src/PerturbedEquilibrium/ResponseMatrices.jl
+++ b/src/PerturbedEquilibrium/ResponseMatrices.jl
@@ -241,7 +241,7 @@ function calc_plasma_inductance(
 end
 
 """
-    pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::Vector{Float64}
+    pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::AbstractVector{Float64}
 
 Pack complex mode coefficients into real/imaginary pairs for Green's function application.
 
@@ -253,9 +253,14 @@ Converts [a+bi, c+di, ...] to [a, b, c, d, ...]
 ## Returns
 - Packed real/imaginary array [2*mpert]
 """
-function pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::Vector{Float64}
+function pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::AbstractVector{Float64}
     mpert = length(modes)
     packed = zeros(Float64, 2 * mpert)
+    return pack_complex_to_realimag!(packed, modes)
+end
+
+function pack_complex_to_realimag!(packed::AbstractVector{Float64}, modes::AbstractVector{ComplexF64})::AbstractVector{Float64}
+    mpert = length(modes)
     for i in 1:mpert
         packed[2*i - 1] = real(modes[i])
         packed[2*i] = imag(modes[i])
@@ -319,14 +324,16 @@ function apply_green_function(
     return apply_green_function!(chi_theta, green, mode_coeffs)
 end
 
-function apply_green_function!(
+@with_pool pool function apply_green_function!(
     chi_theta::AbstractVector{Float64},
     green::Matrix{Float64},
     mode_coeffs::AbstractVector{ComplexF64}
 )
     # Pack complex coefficients to real/imag format for Green's function
     # Format: [Re(mode_1), Im(mode_1), Re(mode_2), Im(mode_2), ...]
-    packed_coeffs = pack_complex_to_realimag(mode_coeffs)
+    mpert = length(mode_coeffs)
+    packed_coeffs = zeros!(pool, Float64, 2 * mpert) 
+    pack_complex_to_realimag!(packed_coeffs, mode_coeffs)
 
     # Apply Green's function: chi_theta = green * b_fourier
     # Extract only plasma surface rows (first mtheta rows)

--- a/src/PerturbedEquilibrium/ResponseMatrices.jl
+++ b/src/PerturbedEquilibrium/ResponseMatrices.jl
@@ -241,7 +241,7 @@ function calc_plasma_inductance(
 end
 
 """
-    pack_complex_to_realimag(modes::Vector{ComplexF64})::Vector{Float64}
+    pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::Vector{Float64}
 
 Pack complex mode coefficients into real/imaginary pairs for Green's function application.
 
@@ -253,7 +253,7 @@ Converts [a+bi, c+di, ...] to [a, b, c, d, ...]
 ## Returns
 - Packed real/imaginary array [2*mpert]
 """
-function pack_complex_to_realimag(modes::Vector{ComplexF64})::Vector{Float64}
+function pack_complex_to_realimag(modes::AbstractVector{ComplexF64})::Vector{Float64}
     mpert = length(modes)
     packed = zeros(Float64, 2 * mpert)
     for i in 1:mpert
@@ -264,7 +264,7 @@ function pack_complex_to_realimag(modes::Vector{ComplexF64})::Vector{Float64}
 end
 
 """
-    unpack_realimag_to_complex(packed::Vector{Float64})::Vector{ComplexF64}
+    unpack_realimag_to_complex(packed::AbstractVector{Float64})::Vector{ComplexF64}
 
 Unpack real/imaginary pairs back to complex coefficients.
 
@@ -276,7 +276,7 @@ Converts [a, b, c, d, ...] to [a+bi, c+di, ...]
 ## Returns
 - Complex mode coefficients [mpert]
 """
-function unpack_realimag_to_complex(packed::Vector{Float64})::Vector{ComplexF64}
+function unpack_realimag_to_complex(packed::AbstractVector{Float64})::Vector{ComplexF64}
     mpert = length(packed) ÷ 2
     modes = zeros(ComplexF64, mpert)
     for i in 1:mpert
@@ -320,9 +320,9 @@ function apply_green_function(
 end
 
 function apply_green_function!(
-    chi_theta::Vector{Float64},
+    chi_theta::AbstractVector{Float64},
     green::Matrix{Float64},
-    mode_coeffs::Vector{ComplexF64}
+    mode_coeffs::AbstractVector{ComplexF64}
 )
     # Pack complex coefficients to real/imag format for Green's function
     # Format: [Re(mode_1), Im(mode_1), Re(mode_2), Im(mode_2), ...]

--- a/src/PerturbedEquilibrium/SingularCoupling.jl
+++ b/src/PerturbedEquilibrium/SingularCoupling.jl
@@ -580,14 +580,14 @@ fsurf_indmats = fflxmats * inv(fkaxmats)
 
     # Initialize matrices (mpert x mpert for single toroidal mode number)
     # Green's functions are computed for a specific n, so inductance is only over poloidal modes
-    flux_matrix = unsafe_zeros!(pool, ComplexF64, mpert, mpert)
-    current_matrix = unsafe_zeros!(pool, ComplexF64, mpert, mpert)
+    flux_matrix = zeros!(pool, ComplexF64, mpert, mpert)
+    current_matrix = zeros!(pool, ComplexF64, mpert, mpert)
 
     # Pre-allocate loop buffers from pool
-    vbwp_mn = unsafe_zeros!(pool, ComplexF64, mpert)
-    chi_theta = unsafe_zeros!(pool, Float64, mtheta)
-    che_theta = unsafe_zeros!(pool, Float64, mtheta)
-    kax_theta = unsafe_zeros!(pool, Float64, mtheta)
+    vbwp_mn = zeros!(pool, ComplexF64, mpert)
+    chi_theta = zeros!(pool, Float64, mtheta)
+    che_theta = zeros!(pool, Float64, mtheta)
+    kax_theta = zeros!(pool, Float64, mtheta)
 
     # For each poloidal mode, compute surface current from Green's functions
     for i in 1:mpert

--- a/src/PerturbedEquilibrium/SingularCoupling.jl
+++ b/src/PerturbedEquilibrium/SingularCoupling.jl
@@ -563,7 +563,7 @@ ENDDO
 fsurf_indmats = fflxmats * inv(fkaxmats)
 ```
 """
-function compute_surface_inductance_from_greens(
+@with_pool pool function compute_surface_inductance_from_greens(
     grri::Matrix{Float64},
     grre::Matrix{Float64},
     ffs_intr::ForceFreeStatesInternal,
@@ -580,21 +580,27 @@ function compute_surface_inductance_from_greens(
 
     # Initialize matrices (mpert x mpert for single toroidal mode number)
     # Green's functions are computed for a specific n, so inductance is only over poloidal modes
-    flux_matrix = zeros(ComplexF64, mpert, mpert)
-    current_matrix = zeros(ComplexF64, mpert, mpert)
+    flux_matrix = unsafe_zeros!(pool, ComplexF64, mpert, mpert)
+    current_matrix = unsafe_zeros!(pool, ComplexF64, mpert, mpert)
+
+    # Pre-allocate loop buffers from pool
+    vbwp_mn = unsafe_zeros!(pool, ComplexF64, mpert)
+    chi_theta = unsafe_zeros!(pool, Float64, mtheta)
+    che_theta = unsafe_zeros!(pool, Float64, mtheta)
+    kax_theta = unsafe_zeros!(pool, Float64, mtheta)
 
     # For each poloidal mode, compute surface current from Green's functions
     for i in 1:mpert
         # Unit flux for mode i
-        vbwp_mn = zeros(ComplexF64, mpert)
+        vbwp_mn .= 0.0
         vbwp_mn[i] = 1.0
 
         # Apply Green's functions using same approach as ResponseMatrices.jl
-        chi_theta = apply_green_function(grri, vbwp_mn)
-        che_theta = apply_green_function(grre, vbwp_mn)
+        apply_green_function!(chi_theta, grri, vbwp_mn)
+        apply_green_function!(che_theta, grre, vbwp_mn)
 
         # Surface current from potential jump
-        kax_theta = (chi_theta .- che_theta) ./ μ₀
+        @. kax_theta = (chi_theta - che_theta) / μ₀
 
         # Transform back to Fourier mode space
         kax_modes = ft(kax_theta)

--- a/src/Utilities/FourierTransforms.jl
+++ b/src/Utilities/FourierTransforms.jl
@@ -653,7 +653,7 @@ end
 # ==============================================================================
 
 """
-    fourier_transform!(gil::Matrix{Float64}, gij::Matrix{Float64}, cs::Matrix{Float64}, m00::Int, l00::Int)
+    fourier_transform!(gil::AbstractMatrix{Float64}, gij::AbstractMatrix{Float64}, cs::Matrix{Float64}, m00::Int, l00::Int)
 
 Low-level Fourier transform with offset support for Vacuum module.
 
@@ -665,8 +665,8 @@ have specific block structure (e.g., plasma and wall contributions packed togeth
 
 # Arguments
 
-- `gil::Matrix{Float64}`: Output matrix, updated in-place at offset block
-- `gij::Matrix{Float64}`: Input matrix (mtheta × mtheta) containing theta-space data
+- `gil::AbstractMatrix{Float64}`: Output matrix, updated in-place at offset block
+- `gij::AbstractMatrix{Float64}`: Input matrix (mtheta × mtheta) containing theta-space data
 - `cs::Matrix{Float64}`: Fourier coefficient matrix (mtheta × mpert), either `cslth` or `snlth`
 - `m00::Int`: Row offset in `gil` matrix (0-based indexing convention)
 - `l00::Int`: Column offset in `gil` matrix (0-based indexing convention)
@@ -697,7 +697,7 @@ fourier_transform!(gil, gij, ft.cslth, 0, 0)
 fourier_transform!(gil, gij, ft.snlth, 0, mpert)
 ```
 """
-function fourier_transform!(gil::Matrix{Float64}, gij::Matrix{Float64}, cs::Matrix{Float64}, m00::Int, l00::Int)
+function fourier_transform!(gil::AbstractMatrix{Float64}, gij::AbstractMatrix{Float64}, cs::Matrix{Float64}, m00::Int, l00::Int)
     # Zero out relevant gil block
     mtheta, mpert = size(cs)
     fill!(view(gil, m00+1:m00+mtheta, l00+1:l00+mpert), 0.0)

--- a/src/Vacuum/Kernel2D.jl
+++ b/src/Vacuum/Kernel2D.jl
@@ -84,7 +84,7 @@ but grad_greenfunction is not since it fills a different block of the
   - Uses Gaussian quadrature near singular points for improved accuracy
   - Implements analytical singularity removal [Chance Phys. Plasmas 1997 2161]
 """
-function kernel!(
+@with_pool pool function kernel!(
     grad_greenfunction::AbstractMatrix{Float64},
     greenfunction::AbstractMatrix{Float64},
     observer::Union{PlasmaGeometry,WallGeometry},
@@ -124,12 +124,16 @@ function kernel!(
 
     # Precompute 5-point Lagrange stencils for the 8-point Gaussian nodes.
     stencils_left, stencils_right = GL8_LAGRANGE_STENCILS
-    sing_idx = zeros(Int, 5)
+    sing_idx = zeros!(pool, Int, 5)
 
     # Precompute source derivatives on the theta grid once used in Simpson integration
     # The Gaussian singular-panel points are off-grid, so those still use spline evaluation directly.
-    dx_dtheta_grid = d1_spline_x(theta_grid)
-    dz_dtheta_grid = d1_spline_z(theta_grid)
+    dx_dtheta_grid = acquire!(pool, eltype(source.x), mtheta)
+    dz_dtheta_grid = acquire!(pool, eltype(source.z), mtheta)
+
+    # Call in-place API to avoid allocations
+    d1_spline_x(dx_dtheta_grid, theta_grid)
+    d1_spline_z(dz_dtheta_grid, theta_grid)
 
     # Loop through observer points
     for j in 1:mtheta

--- a/src/Vacuum/Kernel2D.jl
+++ b/src/Vacuum/Kernel2D.jl
@@ -638,7 +638,7 @@ according to equations (36)-(42) of Chance 1997. Replaces `green` from Fortran c
   - The coupling terms include the Jacobian factor from the coordinate transformation
   - By default uses the 2007 Legendre function implementation (Bulirsch + Gaussian integration)
 """
-function green(x_obs::Float64, z_obs::Float64, x_source::Float64, z_source::Float64, dx_dtheta::Float64, dz_dtheta::Float64, n::Int; uselegacygreenfunction::Bool=false)
+@with_pool pool function green(x_obs::Float64, z_obs::Float64, x_source::Float64, z_source::Float64, dx_dtheta::Float64, dz_dtheta::Float64, n::Int; uselegacygreenfunction::Bool=false)
 
     x_obs2 = x_obs^2
     x_source2 = x_source^2
@@ -660,10 +660,11 @@ function green(x_obs::Float64, z_obs::Float64, x_source::Float64, z_source::Floa
 
     # Legendre functions for
     # P⁰ = p0, P¹ = p1, Pⁿ = pn, Pⁿ⁺¹ = pnp1
+    legendre = acquire!(pool, Float64, n + 2)
     if uselegacygreenfunction
-        legendre = Pn_minus_half_1997(s, n)
+        Pn_minus_half_1997!(legendre, s, n)
     else
-        legendre = Pn_minus_half_2007(s, n)
+        Pn_minus_half_2007!(legendre, s, n)
     end
 
     p0 = legendre[1]

--- a/src/Vacuum/Kernel2D.jl
+++ b/src/Vacuum/Kernel2D.jl
@@ -85,8 +85,8 @@ but grad_greenfunction is not since it fills a different block of the
   - Implements analytical singularity removal [Chance Phys. Plasmas 1997 2161]
 """
 function kernel!(
-    grad_greenfunction::Matrix{Float64},
-    greenfunction::Matrix{Float64},
+    grad_greenfunction::AbstractMatrix{Float64},
+    greenfunction::AbstractMatrix{Float64},
     observer::Union{PlasmaGeometry,WallGeometry},
     source::Union{PlasmaGeometry,WallGeometry},
     n::Int

--- a/src/Vacuum/Vacuum.jl
+++ b/src/Vacuum/Vacuum.jl
@@ -4,6 +4,7 @@ using TOML, SpecialFunctions, LinearAlgebra, Printf
 using FastInterpolations: cubic_interp, deriv1, PeriodicBC, NaturalBC
 using FastGaussQuadrature: gausslegendre
 using StaticArrays: SVector
+using AdaptiveArrayPools
 
 # Import parent modules
 import ..Equilibrium
@@ -65,7 +66,7 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
   - The vacuum response includes plasma-plasma and plasma-wall coupling effects
   - For n=0 modes with closed walls, a regularization factor is added to prevent singularities
 """
-function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings; green_only=false)
+@with_pool pool function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings; green_only=false)
 
     # Initialization and allocations
     (; mtheta, mpert, mlow, n, force_wv_symmetry) = inputs
@@ -79,8 +80,8 @@ function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSe
     # Allocate arrays for both Green's functions
     grri = zeros(2 * mtheta, 2 * mpert)  # Interior (kernelsign=-1)
     grre = zeros(2 * mtheta, 2 * mpert)  # Exterior (kernelsign=+1)
-    grad_green = zeros(2 * mtheta, 2 * mtheta)
-    green_temp = zeros(mtheta, mtheta)
+    grad_green = unsafe_zeros!(pool, 2 * mtheta, 2 * mtheta)
+    green_temp = unsafe_zeros!(pool, mtheta, mtheta)
 
     # Fourier transforms offsets into grri/grre: first mtheta rows are plasma as observer, second are wall
     # First mpert columns are real (cosine), second mpert are imaginary (sine)
@@ -128,8 +129,10 @@ function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSe
     # grre: exterior potential (kernelsign=+1)
 
     # Make copies for each kernelsign
-    grad_green_interior = copy(grad_green)
-    grad_green_exterior = copy(grad_green)
+    grad_green_interior = unsafe_similar!(pool, grad_green)
+    grad_green_exterior = unsafe_similar!(pool, grad_green)
+    grad_green_interior .= grad_green
+    grad_green_exterior .= grad_green
 
     # Apply kernelsign transformations
     apply_kernelsign!(grad_green_interior, -1.0, mtheta)  # Interior

--- a/src/Vacuum/Vacuum.jl
+++ b/src/Vacuum/Vacuum.jl
@@ -27,7 +27,7 @@ export extract_plasma_surface_at_psi
 Apply kernelsign transformation to Green's function matrix.
 For kernelsign < 0 (interior potential), multiply by -1 and add 2 to diagonal.
 """
-function apply_kernelsign!(grad_greenfunction_mat::Matrix{Float64}, kernelsign::Float64, mtheta::Int)
+function apply_kernelsign!(grad_greenfunction_mat::AbstractMatrix{Float64}, kernelsign::Float64, mtheta::Int)
     if kernelsign < 0
         grad_greenfunction_mat .*= kernelsign
         # Account for factor of 2 in diagonal terms [Chance Phys. Plasmas 1997 2161 eq. 90]
@@ -80,8 +80,8 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
     # Allocate arrays for both Green's functions
     grri = zeros(2 * mtheta, 2 * mpert)  # Interior (kernelsign=-1)
     grre = zeros(2 * mtheta, 2 * mpert)  # Exterior (kernelsign=+1)
-    grad_green = unsafe_zeros!(pool, 2 * mtheta, 2 * mtheta)
-    green_temp = unsafe_zeros!(pool, mtheta, mtheta)
+    grad_green = zeros!(pool, 2 * mtheta, 2 * mtheta)
+    green_temp = zeros!(pool, mtheta, mtheta)
 
     # Fourier transforms offsets into grri/grre: first mtheta rows are plasma as observer, second are wall
     # First mpert columns are real (cosine), second mpert are imaginary (sine)
@@ -129,8 +129,8 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
     # grre: exterior potential (kernelsign=+1)
 
     # Make copies for each kernelsign
-    grad_green_interior = unsafe_similar!(pool, grad_green)
-    grad_green_exterior = unsafe_similar!(pool, grad_green)
+    grad_green_interior = similar!(pool, grad_green)
+    grad_green_exterior = similar!(pool, grad_green)
     grad_green_interior .= grad_green
     grad_green_exterior .= grad_green
 


### PR DESCRIPTION
## Summary

Introduce [AdaptiveArrayPools.jl](https://github.com/ProjectTorreyPines/AdaptiveArrayPools.jl) to recycle temporary arrays across **14 functions in 5 modules**, eliminating up to 99% of heap allocations and reducing GC pressure by ~40–50% (vs `develop`).

## Motivation

After PRs #164 and #165, the remaining allocation hotspots are temporary computation buffers in tight loops (ODE derivatives, singular surface analysis, Green's function kernels). These were previously either fresh-allocated each call (`zeros(...)`) or manually pre-allocated in structs (`OdeState.amat`, `.bmat`, `.tmp`, etc.).

[AdaptiveArrayPools.jl](https://github.com/ProjectTorreyPines/AdaptiveArrayPools.jl) replaces both with scoped, task-local array recycling via `@with_pool`. Arrays are recycled on scope exit, and each `Task` gets its own pool via `task_local_storage` — so it's inherently safe for future parallelization, unlike the ad-hoc struct field approach.

### Basic usage

```julia
# Before — fresh heap allocations every call (compute_sing_mmat! had 12 of these)
function compute_sing_mmat!(mmat, singp, ...)
    singfac = zeros(Float64, Npert, 4)
    f_lower = zeros(ComplexF64, Npert, Npert, sing_order + 1)
    g_lower = zeros(ComplexF64, Npert, Npert, sing_order + 1)
    tmp_vec = Vector{ComplexF64}(undef, Npert)
    # ... use temporaries, then they become garbage
end

# After — pool-recycled buffers, zero heap allocations
@with_pool pool function compute_sing_mmat!(mmat, singp, ...)
    singfac = zeros!(pool, Float64, Npert, 4)  # recycled, zero-initialized
    f_lower = zeros!(pool, ComplexF64, Npert, Npert, sing_order + 1)
    g_lower = zeros!(pool, ComplexF64, Npert, Npert, sing_order + 1)
    tmp_vec = acquire!(pool, ComplexF64, Npert)  # recycled, uninitialized
    # ... use temporaries, then they're returned to pool on scope exit
end
```

`zeros!`/`acquire!` return `SubArray` views into the pool's backing storage, so some function signatures were widened from concrete types (e.g. `Vector` → `AbstractVector`, `Matrix` → `AbstractMatrix`). For cases that strictly require a native `Array` (e.g. LAPACK wrappers), `unsafe_zeros!`/`unsafe_acquire!` variants are available. See the [AdaptiveArrayPools.jl docs](https://github.com/ProjectTorreyPines/AdaptiveArrayPools.jl) for details.

## Changes

### Pool integration across hot paths

| Module | Functions | Pool arrays |
|--------|-----------|:-----------:|
| Equilibrium | `direct_get_bfield!`, `equilibrium_solver` | 6 |
| Vacuum | `compute_vacuum_response`, `kernel!`, `green` | 7 |
| ForceFreeStates | `compute_sing_mmat!`, `sing_der!`, `sing_matmul!`, `solve_higher_order_vmat!`, `check_for_zero_crossings!`, `compute_smallest_eigenvalue`, `free_run!` | 30+ |
| PerturbedEquilibrium | `apply_green_function!`, `compute_surface_inductance_from_greens` | 7 |

### OdeState cleanup

Removed 9 temporary workspace fields from `OdeState` (`amat`, `bmat`, `cmat`, `fmat_lower`, `kmat`, `gmat`, `tmp`, `Afact`, `singfac_vec`). These were pre-allocated buffers for `sing_der!` that leaked implementation details into the struct. Now pool-allocated locally in `sing_der!` where they belong.

### In-place operation upgrades

- `sing_der!`: Direct `LAPACK.potrf!/potrs!` calls replace `cholesky!(Hermitian(...))`/`ldiv!` to avoid wrapper allocations in the ODE hot loop
- `compute_sing_mmat!`: All `A * b` mat-vec products replaced with `mul!(tmp, A, b)` chains
- `free_run!`: `wp` and `wpt`/`wvt` computations converted to `mul!` chains
- `apply_green_function!`: New in-place variant using pool-allocated packing buffer
- Legendre functions: In-place `Pn_minus_half_1997!`/`Pn_minus_half_2007!` variants

## Benchmark

Measured with `@timed` loop (N=10), single-threaded BLAS, warmed JIT. Values below are **per-run averages** (total ÷ 10).

**`DIIID-like_ideal_example`**

| | Allocations | Alloc size | Runtime | GC % |
|---|---|---|---|---|
| `develop (aa2f1ed)` | 8.519 M | 2.007 GiB | 2.864 s | 17.7% |
| + PRs #164+#165 (FastInterpolations) | 3.380 M | 0.919 GiB | 2.336 s | 12.8% |
| + This PR | 0.097 M | 0.627 GiB | 2.339 s | 10.6% |
| **Cumulative change** | **-98.9%** | **-68.8%** | **-18.3%** | |

**`Solovev_ideal_example`**

| | Allocations | Alloc size | Runtime | GC % |
|---|---|---|---|---|
| `develop (aa2f1ed)` | 12.919 M | 1.468 GiB | 4.243 s | 11.0% |
| + PRs #164+#165 | 7.879 M | 0.919 GiB | 3.835 s | 7.6% |
| + This PR | 0.058 M | 0.512 GiB | 3.817 s | 5.0% |
| **Cumulative change** | **-99.6%** | **-65.1%** | **-10.0%** | |

The primary win from this PR is **allocation count elimination** (~97-99% reduction vs `develop`), which cuts GC collections.

## Safety notes

- All pool-allocated arrays are scoped temporaries — no pool array escapes via return values, struct fields, or closures (verified by manual audit of all 14 call sites)
- Persistent outputs (`grri`/`grre`, `VacuumData`, `mmat`, interpolants) use standard heap allocation
- `@with_pool` guarantees cleanup via `try/finally` — arrays are returned to pool even on error
