### PR TITLE
Restrict Claude review 

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,24 +1,16 @@
 name: Claude Code Review
 
 on:
-  # pull_request:
-  #   types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-  pull_request_review:
-    types: [submitted]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run when explicitly requested via "@claude review" in a PR comment.
+    # Does NOT trigger on subsequent commits, pushes, or other comments.
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review')
 
     runs-on: ubuntu-latest
     permissions:
@@ -40,7 +32,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number }}
 
             Please review this pull request and provide feedback on:
             - Code quality and best practices


### PR DESCRIPTION
Restrict Claude review to explicit comment requests

Trigger changed from pull_request_review:submitted to issue_comment:created with a job condition requiring '@claude review' in the comment body and the comment to be on a PR. Prevents auto-reviews on every submitted review or after subsequent commits/comments.