### PR TITLE
DOCS - BUG FIX - Set devbranch to develop

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,6 +37,6 @@ makedocs(;
 deploydocs(;
     repo="github.com/OpenFUSIONToolkit/GPEC.git",
     branch="gh-pages",
-    devbranch="main",
+    devbranch="develop",
     push_preview=true
 )


### PR DESCRIPTION
## Summary
- `deploydocs` in `docs/make.jl` had `devbranch="main"`, causing the `/dev/` docs to be built from `main` which still has the old JPEC naming
- Changed to `devbranch="develop"` so the `/dev/` URL at https://openfusiontoolkit.github.io/GPEC/dev/ reflects the current develop branch (with correct GPEC naming)

## Test plan
- [ ] Merge to develop and verify the docs CI workflow redeploys `/dev/` with `sitename="GPEC.jl"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)