### PR TITLE
EQUIL - Direct equilibrium improvements + arc-length robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.jld2
 .gitattributes
 Manifest.toml
-build.log
+*.log
 docs/build/
 anaconda_projects/
 modovmc

--- a/benchmarks/equil_spline_comparison.jl
+++ b/benchmarks/equil_spline_comparison.jl
@@ -133,6 +133,8 @@ psi_full = psi_lo .+ (psi_hi - psi_lo) .* sin.(range(0.0, 1.0; length=mpsi_eval+
 
 mask_core = psi_full .< 0.10
 mask_edge = psi_full .> 0.98
+# Edge coordinate: −ln(1−ψ) linearises the q ~ A·ln(1/(1−ψ)) separatrix asymptotics
+t_edge_full = -log.(1.0 .- psi_full[mask_edge])
 
 theta_select = [0.0, 0.25, 0.5, 0.75]
 theta_colors = [:blue, :green, :darkorange, :purple]
@@ -162,12 +164,25 @@ for (idx, (pname, spl_getter)) in enumerate(profile_specs)
         title="$pname — full domain  (psihigh=$psihigh_arg)")
     p_core = plot(psi_full[mask_core], y_ref[mask_core]; lw=2,
         color=method_color[ref_method], ls=method_style[ref_method],
-        label=method_label[ref_method], xlabel="ψ", ylabel=pname, title="Deep core  (ψ < 0.10)")
-    p_edge = plot(psi_full[mask_edge], y_ref[mask_edge]; lw=2,
+        label=method_label[ref_method], xlabel="ψ  (log scale)", ylabel=pname,
+        title="Deep core  (ψ < 0.10)", xscale=:log10)
+    p_edge = plot(t_edge_full, y_ref[mask_edge]; lw=2,
         color=method_color[ref_method], ls=method_style[ref_method],
-        label=method_label[ref_method], xlabel="ψ", ylabel=pname, title="Far edge  (ψ > 0.98)")
+        label=method_label[ref_method], xlabel="−ln(1−ψ)", ylabel=pname,
+        title="Far edge  (ψ > 0.98)")
     p_diff = plot(; xlabel="ψ", ylabel="Δ$pname", title="Difference (vs efit)")
     hline!(p_diff, [0.0]; color=:black, lw=1, ls=:dot, label="")
+
+    # Scatter markers at actual ψ grid nodes for reference method
+    ref_xs = pe_ref.rzphi_xs
+    ref_ys = [spl_ref(ψ) for ψ in ref_xs]
+    scatter!(p_full, ref_xs, ref_ys; ms=3, markerstrokewidth=0, color=method_color[ref_method], label="")
+    let mask = ref_xs .< 0.10
+        scatter!(p_core, ref_xs[mask], ref_ys[mask]; ms=3, markerstrokewidth=0, color=method_color[ref_method], label="")
+    end
+    let mask = ref_xs .> 0.98
+        scatter!(p_edge, -log.(1.0 .- ref_xs[mask]), ref_ys[mask]; ms=3, markerstrokewidth=0, color=method_color[ref_method], label="")
+    end
 
     for m in compare_methods_active
         spl_m = spl_getter(pes[m])
@@ -178,9 +193,20 @@ for (idx, (pname, spl_getter)) in enumerate(profile_specs)
             label=method_label[m])
         plot!(p_core, psi_full[mask_core], y_m[mask_core]; lw=1.5,
             color=method_color[m], ls=method_style[m], label=method_label[m])
-        plot!(p_edge, psi_full[mask_edge], y_m[mask_edge]; lw=1.5,
+        plot!(p_edge, t_edge_full, y_m[mask_edge]; lw=1.5,
             color=method_color[m], ls=method_style[m], label=method_label[m])
         plot!(p_diff, psi_full, Δy; lw=1.5, color=diff_color[m], label="efit − $(method_label[m])")
+
+        # Scatter markers at actual ψ grid nodes for compare method
+        m_xs = pes[m].rzphi_xs
+        m_ys = [spl_m(ψ) for ψ in m_xs]
+        scatter!(p_full, m_xs, m_ys; ms=3, markerstrokewidth=0, color=method_color[m], label="")
+        let mask = m_xs .< 0.10
+            scatter!(p_core, m_xs[mask], m_ys[mask]; ms=3, markerstrokewidth=0, color=method_color[m], label="")
+        end
+        let mask = m_xs .> 0.98
+            scatter!(p_edge, -log.(1.0 .- m_xs[mask]), m_ys[mask]; ms=3, markerstrokewidth=0, color=method_color[m], label="")
+        end
 
         @printf("  %-14s  vs %-18s  max|Δ|=%.3e  rms|Δ|=%.3e  edge max|Δ|=%.3e\n",
             pname, method_label[m], maximum(abs.(Δy)), sqrt(mean(Δy .^ 2)),
@@ -374,8 +400,8 @@ for (sidx, (sname, fn_getter)) in enumerate(rzphi_specs)
 
     p_full = plot(; xlabel="ψ", ylabel=sname,
         title="$sname — full domain  (psihigh=$psihigh_arg)")
-    p_core = plot(; xlabel="ψ", ylabel=sname, title="Deep core  (ψ < 0.10)")
-    p_edge = plot(; xlabel="ψ", ylabel=sname, title="Far edge  (ψ > 0.98)")
+    p_core = plot(; xlabel="ψ  (log scale)", ylabel=sname, title="Deep core  (ψ < 0.10)", xscale=:log10)
+    p_edge = plot(; xlabel="−ln(1−ψ)", ylabel=sname, title="Far edge  (ψ > 0.98)")
     p_diff = plot(; xlabel="ψ", ylabel="Δ$sname", title="efit − other")
     hline!(p_diff, [0.0]; color=:black, lw=1, ls=:dot, label="")
 
@@ -384,7 +410,11 @@ for (sidx, (sname, fn_getter)) in enumerate(rzphi_specs)
         yd = yd_all[tidx]
         plot!(p_full, psi_full, yd; color=tc, lw=2, label="efit θ=$(θ)")
         plot!(p_core, psi_full[mask_core], yd[mask_core]; color=tc, lw=2, label="efit θ=$(θ)")
-        plot!(p_edge, psi_full[mask_edge], yd[mask_edge]; color=tc, lw=2, label="efit θ=$(θ)")
+        plot!(p_edge, t_edge_full, yd[mask_edge]; color=tc, lw=2, label="efit θ=$(θ)")
+        xs = pe_ref.rzphi_xs; ys = [fn_ref(ψ, θ) for ψ in xs]
+        scatter!(p_full, xs, ys; ms=3, markerstrokewidth=0, color=tc, label="")
+        let mask = xs .< 0.10; scatter!(p_core, xs[mask], ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
+        let mask = xs .> 0.98; scatter!(p_edge, -log.(1.0 .- xs[mask]), ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
     end
 
     println("  $sname:")
@@ -399,10 +429,14 @@ for (sidx, (sname, fn_getter)) in enumerate(rzphi_specs)
                 label="$(method_label[m]) θ=$(θ)")
             plot!(p_core, psi_full[mask_core], yi[mask_core]; color=tc, lw=1.2,
                 ls=method_style[m], label="$(method_label[m]) θ=$(θ)")
-            plot!(p_edge, psi_full[mask_edge], yi[mask_edge]; color=tc, lw=1.2,
+            plot!(p_edge, t_edge_full, yi[mask_edge]; color=tc, lw=1.2,
                 ls=method_style[m], label="$(method_label[m]) θ=$(θ)")
             plot!(p_diff, psi_full, Δ; color=tc, lw=1.2, ls=method_style[m],
                 label="(efit−$(method_label[m])) θ=$(θ)")
+            xs = pes[m].rzphi_xs; ys = [fn_m(ψ, θ) for ψ in xs]
+            scatter!(p_full, xs, ys; ms=3, markerstrokewidth=0, color=tc, label="")
+            let mask = xs .< 0.10; scatter!(p_core, xs[mask], ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
+            let mask = xs .> 0.98; scatter!(p_edge, -log.(1.0 .- xs[mask]), ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
 
             Δc = any(mask_core) ? Δ[mask_core] : [0.0]
             Δe = any(mask_edge) ? Δ[mask_edge] : [0.0]
@@ -436,8 +470,8 @@ for (eidx, (ename, fn_getter)) in enumerate(eqfun_specs)
 
     p_full = plot(; xlabel="ψ", ylabel=ename,
         title="$ename — full domain  (psihigh=$psihigh_arg)")
-    p_core = plot(; xlabel="ψ", ylabel=ename, title="Deep core  (ψ < 0.10)")
-    p_edge = plot(; xlabel="ψ", ylabel=ename, title="Far edge  (ψ > 0.98)")
+    p_core = plot(; xlabel="ψ  (log scale)", ylabel=ename, title="Deep core  (ψ < 0.10)", xscale=:log10)
+    p_edge = plot(; xlabel="−ln(1−ψ)", ylabel=ename, title="Far edge  (ψ > 0.98)")
     p_diff = plot(; xlabel="ψ", ylabel="Δ$ename", title="efit − other")
     hline!(p_diff, [0.0]; color=:black, lw=1, ls=:dot, label="")
 
@@ -446,7 +480,11 @@ for (eidx, (ename, fn_getter)) in enumerate(eqfun_specs)
         yd = yd_all[tidx]
         plot!(p_full, psi_full, yd; color=tc, lw=2, label="efit θ=$(θ)")
         plot!(p_core, psi_full[mask_core], yd[mask_core]; color=tc, lw=2, label="efit θ=$(θ)")
-        plot!(p_edge, psi_full[mask_edge], yd[mask_edge]; color=tc, lw=2, label="efit θ=$(θ)")
+        plot!(p_edge, t_edge_full, yd[mask_edge]; color=tc, lw=2, label="efit θ=$(θ)")
+        xs = pe_ref.rzphi_xs; ys = [fn_ref(ψ, θ) for ψ in xs]
+        scatter!(p_full, xs, ys; ms=3, markerstrokewidth=0, color=tc, label="")
+        let mask = xs .< 0.10; scatter!(p_core, xs[mask], ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
+        let mask = xs .> 0.98; scatter!(p_edge, -log.(1.0 .- xs[mask]), ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
     end
 
     println("  $ename:")
@@ -461,10 +499,14 @@ for (eidx, (ename, fn_getter)) in enumerate(eqfun_specs)
                 label="$(method_label[m]) θ=$(θ)")
             plot!(p_core, psi_full[mask_core], yi[mask_core]; color=tc, lw=1.2,
                 ls=method_style[m], label="$(method_label[m]) θ=$(θ)")
-            plot!(p_edge, psi_full[mask_edge], yi[mask_edge]; color=tc, lw=1.2,
+            plot!(p_edge, t_edge_full, yi[mask_edge]; color=tc, lw=1.2,
                 ls=method_style[m], label="$(method_label[m]) θ=$(θ)")
             plot!(p_diff, psi_full, Δ; color=tc, lw=1.2, ls=method_style[m],
                 label="(efit−$(method_label[m])) θ=$(θ)")
+            xs = pes[m].rzphi_xs; ys = [fn_m(ψ, θ) for ψ in xs]
+            scatter!(p_full, xs, ys; ms=3, markerstrokewidth=0, color=tc, label="")
+            let mask = xs .< 0.10; scatter!(p_core, xs[mask], ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
+            let mask = xs .> 0.98; scatter!(p_edge, -log.(1.0 .- xs[mask]), ys[mask]; ms=3, markerstrokewidth=0, color=tc, label="") end
 
             Δc = any(mask_core) ? Δ[mask_core] : [0.0]
             Δe = any(mask_edge) ? Δ[mask_edge] : [0.0]

--- a/examples/DIIID-like_ideal_example/gpec.toml
+++ b/examples/DIIID-like_ideal_example/gpec.toml
@@ -5,10 +5,11 @@ jac_type = "hamada"                     # Coordinate system (hamada, pest, booze
 power_bp = 0                            # Poloidal field power exponent for Jacobian
 power_b = 0                             # Toroidal field power exponent for Jacobian
 power_r = 0                             # Major radius power exponent for Jacobian
-grid_type = "ldp"                       # Radial grid packing type
+grid_type = "log_asymptotic"            # Radial grid packing type
 psilow = 1e-3                           # Lower limit of normalized flux coordinate
 psihigh = 0.993                         # Upper limit of normalized flux coordinate
-mpsi = 128                              # Number of radial grid points
+mpsi = 0                                # Number of radial grid points (0 = auto-compute from psi_accuracy)
+psi_accuracy = 0.005                    # Target absolute error in q for auto-mpsi
 mtheta = 256                            # Number of poloidal grid points
 newq0 = 0                               # Override for on-axis safety factor (0 = use input value)
 etol = 1e-7                             # Error tolerance for equilibrium solver

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -39,6 +39,7 @@ struct FieldLineDerivParams{I2D<:FastInterpolations.CubicInterpolantND,S<:FastIn
     power_bp::Int
     power_b::Int
     power_r::Int
+    power_rc::Int  # minor radius rfac = √((R-R₀)²+(Z-Z₀)²) power exponent
     bfield::DirectBField
     Bp_floor::Float64  # minimum Bp for integral terms (0 = disabled; arclength sets this to prevent 1/Bp overflow near x-points)
 end
@@ -270,7 +271,7 @@ function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::
     bfield = DirectBField()
     equil_config = raw_profile.config
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, bfield, 0.0)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield, 0.0)
 
     # Use a callback to refine the solution at each step to stay on the flux surface
     function refine_affect!(integrator)
@@ -311,7 +312,8 @@ function direct_fieldline_der!(dy, y, params::FieldLineDerivParams, eta)
     bp = sqrt(params.bfield.br^2 + params.bfield.bz^2)
     bt = params.bfield.f / r
     b = sqrt(bp^2 + bt^2)
-    jac = (bp^params.power_bp) * (b^params.power_b) / (r^params.power_r)
+    rfac = y[2]
+    jac = (bp^params.power_bp) * (b^params.power_b) / (r^params.power_r * rfac^params.power_rc)
 
     # Denominator for d(l_pol)/d(eta) = rfac |B_pol|/denominator
     denominator = params.bfield.bz * cos_eta - params.bfield.br * sin_eta

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -375,6 +375,81 @@ function direct_refine(rfac::Float64, eta::Float64, psi0::Float64, params::Field
 end
 
 """
+    _estimate_log_slope(fieldline_int, raw_profile, ro, zo, rs2, psihigh)
+
+Estimate the logarithmic slope A from two field-line probe integrations near the separatrix,
+using the asymptotic form q(ψ) ≃ −A·ln(1−ψ) (Fitzpatrick 2024, eq. 19).
+
+Returns A = |Δq| / ln(2). Falls back to A=2.0 on integration failure.
+"""
+function _estimate_log_slope(fieldline_int, raw_profile, ro, zo, rs2, psihigh)
+    eps_sep = max(1.0 - psihigh, 0.001)
+    psi1 = clamp(1.0 - 3 * eps_sep, raw_profile.config.psilow + 0.01, 0.999)
+    psi2 = clamp(1.0 - 1.5 * eps_sep, raw_profile.config.psilow + 0.01, 0.999)
+    try
+        out1 = fieldline_int(psi1, raw_profile, ro, zo, rs2)
+        q1 = out1[2].f * out1[1][end, 4] / (2π)
+        out2 = fieldline_int(psi2, raw_profile, ro, zo, rs2)
+        q2 = out2[2].f * out2[1][end, 4] / (2π)
+        A = max(abs(q2 - q1) / log(2), 0.1)
+        @info "Estimated separatrix log slope A = $(@sprintf("%.3f", A)) from probe integrations at psi = $(@sprintf("%.4f", psi1)), $(@sprintf("%.4f", psi2))"
+        return A
+    catch err
+        @warn "Failed to estimate log slope from probe integrations, using default A=2.0: $err"
+        return 2.0
+    end
+end
+
+"""
+    make_optimal_mpsi(psilow, psihigh, A; tau, psi_split_core, psi_split_edge)
+
+Compute the minimum number of radial knots needed to achieve target accuracy τ in q,
+given the separatrix log slope A. Three-region geometric grid: core, pedestal, far edge.
+"""
+function make_optimal_mpsi(psilow, psihigh, A;
+        tau=0.005, psi_split_core=0.15, psi_split_edge=0.95)
+    dlog = (13.0 * tau / A)^(1/4)
+    N_edge = ceil(Int, log((1.0 - psi_split_edge) / (1.0 - psihigh)) / dlog) + 1
+    h_mid = (1.0 - psi_split_edge) * dlog
+    N_mid = ceil(Int, (psi_split_edge - psi_split_core) / h_mid)
+    N_core = ceil(Int, log(psi_split_core / psilow) / dlog)
+    mpsi = N_core + N_mid + N_edge
+    @info "Auto-mpsi: N_core=$N_core + N_mid=$N_mid + N_edge=$N_edge = $mpsi (A=$(@sprintf("%.3f",A)), tau=$tau)"
+    return mpsi
+end
+
+"""
+    make_optimal_psi_grid(psilow, psihigh, mpsi; psi_split_core, psi_split_edge)
+
+Build a three-region ψ grid with mpsi+1 knots:
+- Core  [psilow, psi_split_core]: geometric in log(ψ)        — handles axis behavior
+- Middle [psi_split_core, psi_split_edge]: uniform in ψ       — protects pedestal resolution
+- Edge  [psi_split_edge, psihigh]: geometric in log(1−ψ)     — handles logarithmic separatrix
+
+Knot counts are allocated by equal log-weight with N_edge capped at 50% to protect pedestal.
+"""
+function make_optimal_psi_grid(psilow, psihigh, mpsi;
+        psi_split_core=0.15, psi_split_edge=0.95)
+    log_core = log(psi_split_core / psilow)
+    log_mid  = log(psi_split_edge / psi_split_core)
+    log_edge = log((1.0 - psi_split_edge) / (1.0 - psihigh))
+    log_total = log_core + log_mid + log_edge
+
+    N_edge = clamp(round(Int, mpsi * log_edge / log_total), 2, mpsi ÷ 2)
+    N_core = round(Int, mpsi * log_core / log_total)
+    N_mid  = mpsi - N_edge - N_core
+
+    # Core: [psilow, psi_split_core], geometric in log(ψ)
+    core_pts = [psilow * (psi_split_core / psilow)^(i / N_core) for i in 0:N_core]
+    # Middle: [psi_split_core, psi_split_edge], uniform (skip first to avoid duplicate)
+    mid_pts = [psi_split_core + (psi_split_edge - psi_split_core) * i / N_mid for i in 1:N_mid]
+    # Edge: [psi_split_edge, psihigh], geometric in log(1−ψ) (skip first to avoid duplicate)
+    edge_pts = [1.0 - (1.0 - psi_split_edge) * ((1.0 - psihigh) / (1.0 - psi_split_edge))^(i / N_edge) for i in 1:N_edge]
+
+    return vcat(core_pts, mid_pts, edge_pts)
+end
+
+"""
     equilibrium_solver(raw_profile)
 
 The main driver for the direct equilibrium reconstruction. It orchestrates the entire
@@ -399,20 +474,28 @@ robustness.
     equil_params = raw_profile.config
     psio = raw_profile.psio
     mtheta = equil_params.mtheta
-    mpsi = equil_params.mpsi
     psilow = equil_params.psilow
     psihigh = equil_params.psihigh
 
-    # TODO: grid_type = "original" Fortran logic not yet ported.
-    psi_nodes = Array{Float64}(undef, mpsi + 1)
-    if equil_params.grid_type == "ldp"
-        psi_nodes .= [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
+    # direct_position! must run before building psi_nodes: probe integrations need ro, zo, rs2
+    ro, zo, _, rs2 = direct_position!(raw_profile)
+
+    mpsi = equil_params.mpsi
+    if equil_params.grid_type == "log_asymptotic" && mpsi == 0 && equil_params.psi_accuracy > 0
+        A = _estimate_log_slope(fieldline_int, raw_profile, ro, zo, rs2, psihigh)
+        mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=equil_params.psi_accuracy)
+    elseif mpsi == 0
+        mpsi = 128
+    end
+
+    psi_nodes = if equil_params.grid_type == "log_asymptotic"
+        make_optimal_psi_grid(psilow, psihigh, mpsi)
+    elseif equil_params.grid_type == "ldp"
+        [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
     else
         error("Unsupported grid_type: $(equil_params.grid_type)")
     end
     theta_nodes = range(0.0, 1.0; length=mtheta + 1)
-
-    ro, zo, rs1, rs2 = direct_position!(raw_profile)
 
     sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)
     rzphi_nodes = zeros!(pool, Float64, mpsi + 1, mtheta + 1, 4)

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -41,7 +41,6 @@ struct FieldLineDerivParams{I2D<:FastInterpolations.CubicInterpolantND,S<:FastIn
     power_r::Int
     power_rc::Int  # minor radius rfac = √((R-R₀)²+(Z-Z₀)²) power exponent
     bfield::DirectBField
-    Bp_floor::Float64  # minimum Bp for integral terms (0 = disabled; arclength sets this to prevent 1/Bp overflow near x-points)
 end
 
 """
@@ -271,7 +270,7 @@ function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::
     bfield = DirectBField()
     equil_config = raw_profile.config
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield, 0.0)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield)
 
     # Use a callback to refine the solution at each step to stay on the flux surface
     function refine_affect!(integrator)

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -508,6 +508,7 @@ robustness.
     ro, zo, _, rs2 = direct_position!(raw_profile)
 
     psi_nodes = _build_psi_grid(equil_params, psilow, psihigh, fieldline_int, raw_profile, ro, zo, rs2)
+    mpsi = length(psi_nodes) - 1
     theta_nodes = range(0.0, 1.0; length=mtheta + 1)
 
     sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -449,6 +449,34 @@ function make_optimal_psi_grid(psilow, psihigh, mpsi;
 end
 
 """
+    _build_psi_grid(equil_params, psilow, psihigh, fieldline_int, raw_profile, ro, zo, rs2)
+
+Resolve `mpsi` and build `psi_nodes` for any supported `grid_type`.
+
+For `"log_asymptotic"` with `mpsi=0`, estimates the separatrix log slope from two probe
+integrations and computes the minimum knot count for `psi_accuracy`. For `"ldp"`, uses
+the sin²-spaced grid. Shared by `direct_fieldline_int` and `efit_by_inversion` solvers.
+"""
+function _build_psi_grid(equil_params, psilow, psihigh, fieldline_int, raw_profile, ro, zo, rs2)
+    mpsi = equil_params.mpsi
+    if equil_params.grid_type == "log_asymptotic" && mpsi == 0 && equil_params.psi_accuracy > 0
+        A = _estimate_log_slope(fieldline_int, raw_profile, ro, zo, rs2, psihigh)
+        mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=equil_params.psi_accuracy)
+    elseif mpsi == 0
+        mpsi = 128
+    end
+
+    psi_nodes = if equil_params.grid_type == "log_asymptotic"
+        make_optimal_psi_grid(psilow, psihigh, mpsi)
+    elseif equil_params.grid_type == "ldp"
+        [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
+    else
+        error("Unsupported grid_type: $(equil_params.grid_type)")
+    end
+    return psi_nodes
+end
+
+"""
     equilibrium_solver(raw_profile)
 
 The main driver for the direct equilibrium reconstruction. It orchestrates the entire
@@ -479,21 +507,7 @@ robustness.
     # direct_position! must run before building psi_nodes: probe integrations need ro, zo, rs2
     ro, zo, _, rs2 = direct_position!(raw_profile)
 
-    mpsi = equil_params.mpsi
-    if equil_params.grid_type == "log_asymptotic" && mpsi == 0 && equil_params.psi_accuracy > 0
-        A = _estimate_log_slope(fieldline_int, raw_profile, ro, zo, rs2, psihigh)
-        mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=equil_params.psi_accuracy)
-    elseif mpsi == 0
-        mpsi = 128
-    end
-
-    psi_nodes = if equil_params.grid_type == "log_asymptotic"
-        make_optimal_psi_grid(psilow, psihigh, mpsi)
-    elseif equil_params.grid_type == "ldp"
-        [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
-    else
-        error("Unsupported grid_type: $(equil_params.grid_type)")
-    end
+    psi_nodes = _build_psi_grid(equil_params, psilow, psihigh, fieldline_int, raw_profile, ro, zo, rs2)
     theta_nodes = range(0.0, 1.0; length=mtheta + 1)
 
     sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)

--- a/src/Equilibrium/DirectEquilibriumArcLength.jl
+++ b/src/Equilibrium/DirectEquilibriumArcLength.jl
@@ -98,7 +98,7 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
     equil_config = raw_profile.config
     bfield_ode = DirectBField()
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield_ode, 0.0)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield_ode)
 
     t_min = π * (r - ro)  # minimum arc before termination (half-circumference lower bound)
     condition(u, _t, integrator) = u[2] - zo

--- a/src/Equilibrium/DirectEquilibriumArcLength.jl
+++ b/src/Equilibrium/DirectEquilibriumArcLength.jl
@@ -14,15 +14,15 @@ denominator singularity of the geometric-angle ODE near x-points.
 
 RHS for the arc-length-parameterized level-set ODE.
 
-State `y = [R, Z, ∫dl/Bp, ∫dl/(R²Bp), arc_length]`.
+State `y = [R, Z, ∫dl/Bp, ∫dl/(R²Bp), ∫jac·dl/Bp]`.
 The independent variable `s` is arc length [m].
 
 The tangent direction `(dR/ds, dZ/ds) = (∂ψ/∂Z, −∂ψ/∂R) / |∇ψ|` follows the
 ψ = const level set counterclockwise, staying on the flux surface without correction.
 
-dy[5] = 1 always (equal_arc: Bp/Bp). Near x-points where Bp → 0, the position
-integration (dy[1:2]) remains well-behaved; dy[3:5] use abstol=1e20 so the solver
-never restricts step size for them.
+Near x-points where Bp → 0, the position integration (dy[1:2]) remains well-behaved
+because `grad_norm` never appears in the denominator alone. dy[3:5] use abstol=1e20
+so the solver never restricts step size for them.
 """
 @with_pool pool function arclength_fieldline_der!(dy, y, params::FieldLineDerivParams, _s)
     R, Z = y[1], y[2]
@@ -45,12 +45,17 @@ never restricts step size for them.
     # Bp = |∇ψ| / R (poloidal field [T])
     Bp = grad_norm / R
 
-    # Equal-arc jac: dy[5] = Bp/Bp = 1 always, self-regularizing near x-point.
     # dy[3] and dy[4] use abstol=1e20 so the solver never restricts steps for them.
     Bp_eff = max(Bp, eps(Float64))  # absolute guard against exact Bp=0 only
     dy[3] = 1.0 / Bp_eff           # d/ds [∫dl/Bp]
     dy[4] = 1.0 / (R^2 * Bp_eff)  # d/ds [∫dl/(R²Bp)]
-    dy[5] = 1.0                    # d/ds [arc_length] = Bp/Bp_eff → 1 for equal_arc
+
+    # d/ds [∫jac·dl/Bp]: integrand = Bp^(power_bp−1) · B^power_b / (R^power_r · rfac^power_rc)
+    Bt = params.bfield.f / R
+    B_val = sqrt(Bp^2 + Bt^2)
+    rfac = sqrt((R - params.ro)^2 + (Z - params.zo)^2)
+    rfac_eff = max(rfac, eps(Float64))
+    dy[5] = Bp_eff^(params.power_bp - 1) * B_val^params.power_b / (R^params.power_r * rfac_eff^params.power_rc)
 end
 
 """
@@ -92,10 +97,8 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
 
     equil_config = raw_profile.config
     bfield_ode = DirectBField()
-    # Force equal_arc jac internally (power_bp=1,b=0,r=0): dy[5]=1 regardless of Bp near x-point.
-    # The user jac SFL angle is recovered in post-processing below.
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        1, 0, 0, 0, bfield_ode, 0.0)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield_ode, 0.0)
 
     t_min = π * (r - ro)  # minimum arc before termination (half-circumference lower bound)
     condition(u, _t, integrator) = u[2] - zo
@@ -138,109 +141,7 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
         y_out[i, 5] = sol.u[i][5]
     end
 
-    # Replace arc-length in y_out[:,5] with user-jac SFL angle so equilibrium_solver
-    # receives the expected SFL abscissa ∫jac·dl/Bp normalized to [0,1].
-    # y_out[:,2] = ∫dl/Bp and y_out[:,4] = ∫dl/(R²Bp) are already integrated correctly.
-    _sfl_to_user_jac!(y_out, equil_config, sol, ro, zo,
-        raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio)
-
     # bfield at the starting point carries F and P for the surface-averaged quantities
     return y_out, bfield
 end
 
-"""
-    _sfl_to_user_jac!(y_out, equil_config, sol, ro, zo, psi_in, sq_in, sq_in_deriv, psio)
-
-Replace the arc-length column y_out[:,5] with the user-jac SFL angle ∈ [0,1].
-
-After the equal_arc ODE, y_out[:,5] = arc_length. This converts it to the SFL angle
-for the user's jac_type using integrals already accumulated in the ODE (fast paths) or
-post-processing bfield calls (general path):
-
-Fast paths (no extra bfield calls):
-- Hamada     (power_bp=0, b=0, r=0, rc=0): SFL = ∫dl/Bp,      stored in y_out[:,2]
-- PEST       (power_bp=0, b=0, r=2, rc=0): SFL = ∫dl/(R²Bp),  stored in y_out[:,4]
-- equal_arc  (power_bp=1, b=0, r=0, rc=0): SFL = arc_length,  in y_out[:,5]
-
-General path (bfield calls at each ODE sample point):
-- Boozer     (power_bp=0, b=2, r=0, rc=0): SFL ∝ ∫B²dl/Bp
-- Park       (power_bp=0, b=1, r=0, rc=0): SFL ∝ ∫Bdl/Bp
-- other: SFL ∝ ∫ Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc) dl
-"""
-function _sfl_to_user_jac!(y_out::Matrix{Float64}, equil_config::EquilibriumConfig,
-    sol, ro::Float64, zo::Float64, psi_in, sq_in, sq_in_deriv, psio::Float64)
-    power_bp = equil_config.power_bp
-    power_b  = equil_config.power_b
-    power_r  = equil_config.power_r
-    power_rc = equil_config.power_rc
-
-    if power_bp == 0 && power_b == 0 && power_r == 0 && power_rc == 0
-        # Hamada: ∫dl/Bp already in col 2
-        @. y_out[:, 5] = y_out[:, 2] / y_out[end, 2]
-    elseif power_bp == 0 && power_b == 0 && power_r == 2 && power_rc == 0
-        # PEST: ∫dl/(R²Bp) already in col 4
-        @. y_out[:, 5] = y_out[:, 4] / y_out[end, 4]
-    elseif power_bp == 1 && power_b == 0 && power_r == 0 && power_rc == 0
-        # equal_arc: arc_length → normalize in place
-        y_out[:, 5] ./= y_out[end, 5]
-    else
-        # General case: integrand Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)
-        # Requires bfield at each ODE sample point; trapezoid integration over arc length.
-        _general_jac_from_trajectory!(y_out, sol, ro, zo,
-            power_bp, power_b, power_r, power_rc, psi_in, sq_in, sq_in_deriv, psio)
-    end
-end
-
-"""
-    _general_jac_from_trajectory!(y_out, sol, ro, zo, power_bp, power_b, power_r, power_rc,
-                                   psi_in, sq_in, sq_in_deriv, psio)
-
-Compute the general SFL angle by trapezoid integration over the ODE trajectory.
-
-Integrand at each point: `Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)`
-where `B = √(Bp² + Bt²)`, `Bt = F/R`, and `rfac = √((R−R₀)²+(Z−Z₀)²)`.
-The result is normalized to [0,1] and stored in `y_out[:,5]`.
-"""
-function _general_jac_from_trajectory!(y_out::Matrix{Float64}, sol, ro::Float64, zo::Float64,
-    power_bp::Int, power_b::Int, power_r::Int, power_rc::Int,
-    psi_in, sq_in, sq_in_deriv, psio::Float64)
-    n = length(sol.u)
-    bfield = DirectBField()
-
-    prev_integrand = _jac_integrand(sol.u[1][1], sol.u[1][2], ro, zo,
-        power_bp, power_b, power_r, power_rc, bfield, psi_in, sq_in, sq_in_deriv, psio)
-    y_out[1, 5] = 0.0
-
-    for i in 2:n
-        R, Z = sol.u[i][1], sol.u[i][2]
-        curr_integrand = _jac_integrand(R, Z, ro, zo,
-            power_bp, power_b, power_r, power_rc, bfield, psi_in, sq_in, sq_in_deriv, psio)
-        ds = sol.t[i] - sol.t[i-1]
-        y_out[i, 5] = y_out[i-1, 5] + 0.5 * (prev_integrand + curr_integrand) * ds
-        prev_integrand = curr_integrand
-    end
-
-    total = y_out[end, 5]
-    if total > 0.0
-        y_out[:, 5] ./= total
-    end
-end
-
-"""
-    _jac_integrand(R, Z, ro, zo, power_bp, power_b, power_r, power_rc,
-                   bfield, psi_in, sq_in, sq_in_deriv, psio)
-
-Evaluate the SFL-angle integrand `Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)` at (R, Z).
-"""
-function _jac_integrand(R::Float64, Z::Float64, ro::Float64, zo::Float64,
-    power_bp::Int, power_b::Int, power_r::Int, power_rc::Int,
-    bfield::DirectBField, psi_in, sq_in, sq_in_deriv, psio::Float64)::Float64
-    direct_get_bfield!(bfield, R, Z, psi_in, sq_in, sq_in_deriv, psio; derivs=1)
-    Bp = sqrt(bfield.br^2 + bfield.bz^2)
-    Bt = bfield.f / R
-    B  = sqrt(Bp^2 + Bt^2)
-    rfac = sqrt((R - ro)^2 + (Z - zo)^2)
-    Bp_eff   = max(Bp,   eps(Float64))
-    rfac_eff = max(rfac, eps(Float64))
-    return Bp_eff^(power_bp - 1) * B^power_b / (R^power_r * rfac_eff^power_rc)
-end

--- a/src/Equilibrium/DirectEquilibriumArcLength.jl
+++ b/src/Equilibrium/DirectEquilibriumArcLength.jl
@@ -14,11 +14,15 @@ denominator singularity of the geometric-angle ODE near x-points.
 
 RHS for the arc-length-parameterized level-set ODE.
 
-State `y = [R, Z, ∫dl/Bp, ∫dl/(R²Bp), ∫jac·dl/Bp]`.
+State `y = [R, Z, ∫dl/Bp, ∫dl/(R²Bp), arc_length]`.
 The independent variable `s` is arc length [m].
 
 The tangent direction `(dR/ds, dZ/ds) = (∂ψ/∂Z, −∂ψ/∂R) / |∇ψ|` follows the
 ψ = const level set counterclockwise, staying on the flux surface without correction.
+
+dy[5] = 1 always (equal_arc: Bp/Bp). Near x-points where Bp → 0, the position
+integration (dy[1:2]) remains well-behaved; dy[3:5] use abstol=1e20 so the solver
+never restricts step size for them.
 """
 @with_pool pool function arclength_fieldline_der!(dy, y, params::FieldLineDerivParams, _s)
     R, Z = y[1], y[2]
@@ -40,15 +44,13 @@ The tangent direction `(dR/ds, dZ/ds) = (∂ψ/∂Z, −∂ψ/∂R) / |∇ψ|` f
 
     # Bp = |∇ψ| / R (poloidal field [T])
     Bp = grad_norm / R
-    Bt = params.bfield.f / R
-    B  = sqrt(Bp^2 + Bt^2)
-    jac = Bp^params.power_bp * B^params.power_b / R^params.power_r
 
-    # Smooth floor prevents 1/Bp divergence near x-points.
-    Bp_eff = sqrt(Bp^2 + params.Bp_floor^2)
+    # Equal-arc jac: dy[5] = Bp/Bp = 1 always, self-regularizing near x-point.
+    # dy[3] and dy[4] use abstol=1e20 so the solver never restricts steps for them.
+    Bp_eff = max(Bp, eps(Float64))  # absolute guard against exact Bp=0 only
     dy[3] = 1.0 / Bp_eff           # d/ds [∫dl/Bp]
     dy[4] = 1.0 / (R^2 * Bp_eff)  # d/ds [∫dl/(R²Bp)]
-    dy[5] = jac / Bp_eff           # d/ds [∫jac·dl/Bp]
+    dy[5] = 1.0                    # d/ds [arc_length] = Bp/Bp_eff → 1 for equal_arc
 end
 
 """
@@ -90,10 +92,10 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
 
     equil_config = raw_profile.config
     bfield_ode = DirectBField()
-    Bp0 = sqrt(bfield.psir^2 + bfield.psiz^2) / r
-    Bp_floor = 1e-4 * Bp0  # 0.01% of outboard-midplane Bp
+    # Force equal_arc jac internally (power_bp=1,b=0,r=0): dy[5]=1 regardless of Bp near x-point.
+    # The user jac SFL angle is recovered in post-processing below.
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, bfield_ode, Bp_floor)
+        1, 0, 0, bfield_ode, 0.0)
 
     t_min = π * (r - ro)  # minimum arc before termination (half-circumference lower bound)
     condition(u, _t, integrator) = u[2] - zo
@@ -136,6 +138,39 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
         y_out[i, 5] = sol.u[i][5]
     end
 
+    # Replace arc-length in y_out[:,5] with user-jac SFL angle so equilibrium_solver
+    # receives the expected SFL abscissa ∫jac·dl/Bp normalized to [0,1].
+    # y_out[:,2] = ∫dl/Bp and y_out[:,4] = ∫dl/(R²Bp) are already integrated correctly.
+    _sfl_to_user_jac!(y_out, equil_config)
+
     # bfield at the starting point carries F and P for the surface-averaged quantities
     return y_out, bfield
+end
+
+"""
+    _sfl_to_user_jac!(y_out, equil_config)
+
+Replace the arc-length column y_out[:,5] with the user-jac SFL angle ∈ [0,1].
+
+After the equal_arc ODE, y_out[:,5] = arc_length. This converts it to the SFL angle
+for the user's jac_type using integrals already accumulated in the ODE:
+- Hamada (power_bp=0, b=0, r=0): SFL = ∫dl/Bp, stored in y_out[:,2]
+- PEST   (power_bp=0, b=0, r=2): SFL = ∫dl/(R²Bp), stored in y_out[:,4]
+- equal_arc (power_bp=1, b=0, r=0): SFL = arc_length, already in y_out[:,5]
+"""
+function _sfl_to_user_jac!(y_out::Matrix{Float64}, equil_config::EquilibriumConfig)
+    power_bp = equil_config.power_bp
+    power_b  = equil_config.power_b
+    power_r  = equil_config.power_r
+
+    if power_bp == 0 && power_b == 0 && power_r == 0
+        # Hamada: ∫dl/Bp already in col 2
+        @. y_out[:, 5] = y_out[:, 2] / y_out[end, 2]
+    elseif power_bp == 0 && power_b == 0 && power_r == 2
+        # PEST: ∫dl/(R²Bp) already in col 4
+        @. y_out[:, 5] = y_out[:, 4] / y_out[end, 4]
+    else
+        # equal_arc user jac or unsupported: arc_length → normalize in place
+        y_out[:, 5] ./= y_out[end, 5]
+    end
 end

--- a/src/Equilibrium/DirectEquilibriumArcLength.jl
+++ b/src/Equilibrium/DirectEquilibriumArcLength.jl
@@ -95,7 +95,7 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
     # Force equal_arc jac internally (power_bp=1,b=0,r=0): dy[5]=1 regardless of Bp near x-point.
     # The user jac SFL angle is recovered in post-processing below.
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        1, 0, 0, bfield_ode, 0.0)
+        1, 0, 0, 0, bfield_ode, 0.0)
 
     t_min = π * (r - ro)  # minimum arc before termination (half-circumference lower bound)
     condition(u, _t, integrator) = u[2] - zo
@@ -141,36 +141,106 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
     # Replace arc-length in y_out[:,5] with user-jac SFL angle so equilibrium_solver
     # receives the expected SFL abscissa ∫jac·dl/Bp normalized to [0,1].
     # y_out[:,2] = ∫dl/Bp and y_out[:,4] = ∫dl/(R²Bp) are already integrated correctly.
-    _sfl_to_user_jac!(y_out, equil_config)
+    _sfl_to_user_jac!(y_out, equil_config, sol, ro, zo,
+        raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio)
 
     # bfield at the starting point carries F and P for the surface-averaged quantities
     return y_out, bfield
 end
 
 """
-    _sfl_to_user_jac!(y_out, equil_config)
+    _sfl_to_user_jac!(y_out, equil_config, sol, ro, zo, psi_in, sq_in, sq_in_deriv, psio)
 
 Replace the arc-length column y_out[:,5] with the user-jac SFL angle ∈ [0,1].
 
 After the equal_arc ODE, y_out[:,5] = arc_length. This converts it to the SFL angle
-for the user's jac_type using integrals already accumulated in the ODE:
-- Hamada (power_bp=0, b=0, r=0): SFL = ∫dl/Bp, stored in y_out[:,2]
-- PEST   (power_bp=0, b=0, r=2): SFL = ∫dl/(R²Bp), stored in y_out[:,4]
-- equal_arc (power_bp=1, b=0, r=0): SFL = arc_length, already in y_out[:,5]
+for the user's jac_type using integrals already accumulated in the ODE (fast paths) or
+post-processing bfield calls (general path):
+
+Fast paths (no extra bfield calls):
+- Hamada     (power_bp=0, b=0, r=0, rc=0): SFL = ∫dl/Bp,      stored in y_out[:,2]
+- PEST       (power_bp=0, b=0, r=2, rc=0): SFL = ∫dl/(R²Bp),  stored in y_out[:,4]
+- equal_arc  (power_bp=1, b=0, r=0, rc=0): SFL = arc_length,  in y_out[:,5]
+
+General path (bfield calls at each ODE sample point):
+- Boozer     (power_bp=0, b=2, r=0, rc=0): SFL ∝ ∫B²dl/Bp
+- Park       (power_bp=0, b=1, r=0, rc=0): SFL ∝ ∫Bdl/Bp
+- other: SFL ∝ ∫ Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc) dl
 """
-function _sfl_to_user_jac!(y_out::Matrix{Float64}, equil_config::EquilibriumConfig)
+function _sfl_to_user_jac!(y_out::Matrix{Float64}, equil_config::EquilibriumConfig,
+    sol, ro::Float64, zo::Float64, psi_in, sq_in, sq_in_deriv, psio::Float64)
     power_bp = equil_config.power_bp
     power_b  = equil_config.power_b
     power_r  = equil_config.power_r
+    power_rc = equil_config.power_rc
 
-    if power_bp == 0 && power_b == 0 && power_r == 0
+    if power_bp == 0 && power_b == 0 && power_r == 0 && power_rc == 0
         # Hamada: ∫dl/Bp already in col 2
         @. y_out[:, 5] = y_out[:, 2] / y_out[end, 2]
-    elseif power_bp == 0 && power_b == 0 && power_r == 2
+    elseif power_bp == 0 && power_b == 0 && power_r == 2 && power_rc == 0
         # PEST: ∫dl/(R²Bp) already in col 4
         @. y_out[:, 5] = y_out[:, 4] / y_out[end, 4]
-    else
-        # equal_arc user jac or unsupported: arc_length → normalize in place
+    elseif power_bp == 1 && power_b == 0 && power_r == 0 && power_rc == 0
+        # equal_arc: arc_length → normalize in place
         y_out[:, 5] ./= y_out[end, 5]
+    else
+        # General case: integrand Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)
+        # Requires bfield at each ODE sample point; trapezoid integration over arc length.
+        _general_jac_from_trajectory!(y_out, sol, ro, zo,
+            power_bp, power_b, power_r, power_rc, psi_in, sq_in, sq_in_deriv, psio)
     end
+end
+
+"""
+    _general_jac_from_trajectory!(y_out, sol, ro, zo, power_bp, power_b, power_r, power_rc,
+                                   psi_in, sq_in, sq_in_deriv, psio)
+
+Compute the general SFL angle by trapezoid integration over the ODE trajectory.
+
+Integrand at each point: `Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)`
+where `B = √(Bp² + Bt²)`, `Bt = F/R`, and `rfac = √((R−R₀)²+(Z−Z₀)²)`.
+The result is normalized to [0,1] and stored in `y_out[:,5]`.
+"""
+function _general_jac_from_trajectory!(y_out::Matrix{Float64}, sol, ro::Float64, zo::Float64,
+    power_bp::Int, power_b::Int, power_r::Int, power_rc::Int,
+    psi_in, sq_in, sq_in_deriv, psio::Float64)
+    n = length(sol.u)
+    bfield = DirectBField()
+
+    prev_integrand = _jac_integrand(sol.u[1][1], sol.u[1][2], ro, zo,
+        power_bp, power_b, power_r, power_rc, bfield, psi_in, sq_in, sq_in_deriv, psio)
+    y_out[1, 5] = 0.0
+
+    for i in 2:n
+        R, Z = sol.u[i][1], sol.u[i][2]
+        curr_integrand = _jac_integrand(R, Z, ro, zo,
+            power_bp, power_b, power_r, power_rc, bfield, psi_in, sq_in, sq_in_deriv, psio)
+        ds = sol.t[i] - sol.t[i-1]
+        y_out[i, 5] = y_out[i-1, 5] + 0.5 * (prev_integrand + curr_integrand) * ds
+        prev_integrand = curr_integrand
+    end
+
+    total = y_out[end, 5]
+    if total > 0.0
+        y_out[:, 5] ./= total
+    end
+end
+
+"""
+    _jac_integrand(R, Z, ro, zo, power_bp, power_b, power_r, power_rc,
+                   bfield, psi_in, sq_in, sq_in_deriv, psio)
+
+Evaluate the SFL-angle integrand `Bp^(power_bp−1) ⋅ B^power_b / (R^power_r ⋅ rfac^power_rc)` at (R, Z).
+"""
+function _jac_integrand(R::Float64, Z::Float64, ro::Float64, zo::Float64,
+    power_bp::Int, power_b::Int, power_r::Int, power_rc::Int,
+    bfield::DirectBField, psi_in, sq_in, sq_in_deriv, psio::Float64)::Float64
+    direct_get_bfield!(bfield, R, Z, psi_in, sq_in, sq_in_deriv, psio; derivs=1)
+    Bp = sqrt(bfield.br^2 + bfield.bz^2)
+    Bt = bfield.f / R
+    B  = sqrt(Bp^2 + Bt^2)
+    rfac = sqrt((R - ro)^2 + (Z - zo)^2)
+    Bp_eff   = max(Bp,   eps(Float64))
+    rfac_eff = max(rfac, eps(Float64))
+    return Bp_eff^(power_bp - 1) * B^power_b / (R^power_r * rfac_eff^power_rc)
 end

--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -397,16 +397,26 @@ function equilibrium_solver_by_inversion(
 )
     equil_params = raw_profile.config
     psio = raw_profile.psio
-    mpsi = equil_params.mpsi
     mtheta = equil_params.mtheta
     psilow = equil_params.psilow
     psihigh = equil_params.psihigh
 
-    # Build target psi_norm grid (same ldp scheme as direct solver)
-    psi_nodes = [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
+    # Find magnetic axis and separatrix before building psi_nodes (needed for probe integrations)
+    ro, zo, _, rs2 = direct_position!(raw_profile)
 
-    # Find magnetic axis and separatrix
-    ro, zo, _, _ = direct_position!(raw_profile)
+    mpsi = equil_params.mpsi
+    if equil_params.grid_type == "log_asymptotic" && mpsi == 0 && equil_params.psi_accuracy > 0
+        A = _estimate_log_slope(direct_fieldline_int, raw_profile, ro, zo, rs2, psihigh)
+        mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=equil_params.psi_accuracy)
+    elseif mpsi == 0
+        mpsi = 128
+    end
+
+    psi_nodes = if equil_params.grid_type == "log_asymptotic"
+        make_optimal_psi_grid(psilow, psihigh, mpsi)
+    else
+        [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
+    end
 
     # Detect plasma topology for sinh-stretching direction
     topology = classify_topology(raw_profile, psio)

--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -404,19 +404,7 @@ function equilibrium_solver_by_inversion(
     # Find magnetic axis and separatrix before building psi_nodes (needed for probe integrations)
     ro, zo, _, rs2 = direct_position!(raw_profile)
 
-    mpsi = equil_params.mpsi
-    if equil_params.grid_type == "log_asymptotic" && mpsi == 0 && equil_params.psi_accuracy > 0
-        A = _estimate_log_slope(direct_fieldline_int, raw_profile, ro, zo, rs2, psihigh)
-        mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=equil_params.psi_accuracy)
-    elseif mpsi == 0
-        mpsi = 128
-    end
-
-    psi_nodes = if equil_params.grid_type == "log_asymptotic"
-        make_optimal_psi_grid(psilow, psihigh, mpsi)
-    else
-        [psilow + (psihigh - psilow) * sin((ipsi / mpsi) * (π / 2))^2 for ipsi in 0:mpsi]
-    end
+    psi_nodes = _build_psi_grid(equil_params, psilow, psihigh, direct_fieldline_int, raw_profile, ro, zo, rs2)
 
     # Detect plasma topology for sinh-stretching direction
     topology = classify_topology(raw_profile, psio)

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -19,10 +19,11 @@ Bundles all necessary settings originally specified in the equil fortran namelis
   - `power_rc::Int` - Minor radius (rfac = √((R-R₀)²+(Z-Z₀)²)) power exponent for Jacobian
   - `r0exp::Float64` - Major radius normalization for CHEASE/EQDSK [m]
   - `b0exp::Float64` - On-axis toroidal field normalization for CHEASE/EQDSK [T]
-  - `grid_type::String` - Grid type for flux surface discretization ("ldp", etc.)
+  - `grid_type::String` - Grid type for flux surface discretization ("log_asymptotic", "ldp")
   - `psilow::Float64` - Lower limit of normalized flux coordinate
   - `psihigh::Float64` - Upper limit of normalized flux coordinate
-  - `mpsi::Int` - Number of radial grid points
+  - `mpsi::Int` - Number of radial grid points (0 = auto-compute from psi_accuracy)
+  - `psi_accuracy::Float64` - Target absolute error in q for auto-mpsi (used when mpsi=0 and grid_type="log_asymptotic")
   - `mtheta::Int` - Number of poloidal grid points
   - `newq0::Int` - Override for on-axis safety factor (0 = use input value)
   - `etol::Float64` - Error tolerance for equilibrium solver
@@ -41,10 +42,11 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     power_r::Int = 0
     power_rc::Int = 0
 
-    grid_type::String = "ldp"
+    grid_type::String = "log_asymptotic"
     psilow::Float64 = 1e-2
     psihigh::Float64 = 0.994
-    mpsi::Int = 128
+    mpsi::Int = 0
+    psi_accuracy::Float64 = 0.005
     mtheta::Int = 256
 
     newq0::Int = 0
@@ -57,7 +59,7 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     Modified internal constructor that enforces self consistency within the inputs
     """
     function EquilibriumConfig(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
-        grid_type, psilow, psihigh, mpsi, mtheta, newq0, etol,
+        grid_type, psilow, psihigh, mpsi, psi_accuracy, mtheta, newq0, etol,
         force_termination, use_galgrid)
         if jac_type == "hamada"
             @info "Forcing hamada coordinate jacobian exponents: power_*"
@@ -94,7 +96,7 @@ Bundles all necessary settings originally specified in the equil fortran namelis
         end
         psihigh = min(psihigh, 1.0)
         return new(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
-            grid_type, psilow, psihigh, mpsi, mtheta, newq0, etol,
+            grid_type, psilow, psihigh, mpsi, psi_accuracy, mtheta, newq0, etol,
             force_termination, use_galgrid)
     end
 end

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -14,8 +14,9 @@ Bundles all necessary settings originally specified in the equil fortran namelis
   - `eq_filename::String` - Path to equilibrium input file
   - `jac_type::String` - Jacobian coordinate type ("hamada", "pest", "equal_arc", "boozer", "park", "other")
   - `power_bp::Int` - Poloidal field power exponent for Jacobian
-  - `power_b::Int` - Toroidal field power exponent for Jacobian
+  - `power_b::Int` - Total field power exponent for Jacobian
   - `power_r::Int` - Major radius power exponent for Jacobian
+  - `power_rc::Int` - Minor radius (rfac = √((R-R₀)²+(Z-Z₀)²)) power exponent for Jacobian
   - `r0exp::Float64` - Major radius normalization for CHEASE/EQDSK [m]
   - `b0exp::Float64` - On-axis toroidal field normalization for CHEASE/EQDSK [T]
   - `grid_type::String` - Grid type for flux surface discretization ("ldp", etc.)
@@ -38,6 +39,7 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     power_bp::Int = 0
     power_b::Int = 0
     power_r::Int = 0
+    power_rc::Int = 0
 
     grid_type::String = "ldp"
     psilow::Float64 = 1e-2
@@ -54,41 +56,44 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     """
     Modified internal constructor that enforces self consistency within the inputs
     """
-    function EquilibriumConfig(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r,
+    function EquilibriumConfig(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
         grid_type, psilow, psihigh, mpsi, mtheta, newq0, etol,
         force_termination, use_galgrid)
         if jac_type == "hamada"
             @info "Forcing hamada coordinate jacobian exponents: power_*"
-            power_b = 0
-            power_bp = 0
-            power_r = 0
+            power_b = 0; power_bp = 0; power_r = 0; power_rc = 0
         elseif jac_type == "pest"
             @info "Forcing pest coordinate jacobian exponents: power_*"
-            power_b = 0
-            power_bp = 0
-            power_r = 2
+            power_b = 0; power_bp = 0; power_r = 2; power_rc = 0
         elseif jac_type == "equal_arc"
             @info "Forcing equal_arc coordinate jacobian exponents: power_*"
-            power_b = 0
-            power_bp = 1
-            power_r = 0
+            power_b = 0; power_bp = 1; power_r = 0; power_rc = 0
         elseif jac_type == "boozer"
             @info "Forcing boozer coordinate jacobian exponents: power_*"
-            power_b = 2
-            power_bp = 0
-            power_r = 0
+            power_b = 2; power_bp = 0; power_r = 0; power_rc = 0
         elseif jac_type == "park"
             @info "Forcing park coordinate jacobian exponents: power_*"
-            power_b = 1
-            power_bp = 0
-            power_r = 0
+            power_b = 1; power_bp = 0; power_r = 0; power_rc = 0
         elseif jac_type == "other"
-            @info "Using manual jacobian exponents: power b, bp, r = $(power_b), $(power_bp), $(power_r)"
-        elseif jac_type != "other"
+            # Normalize to a named type when the powers match, so fast paths are taken.
+            if     power_b == 0 && power_bp == 0 && power_r == 0 && power_rc == 0
+                jac_type = "hamada";    @info "Recognized hamada jacobian from power exponents"
+            elseif power_b == 0 && power_bp == 0 && power_r == 2 && power_rc == 0
+                jac_type = "pest";      @info "Recognized pest jacobian from power exponents"
+            elseif power_b == 0 && power_bp == 1 && power_r == 0 && power_rc == 0
+                jac_type = "equal_arc"; @info "Recognized equal_arc jacobian from power exponents"
+            elseif power_b == 2 && power_bp == 0 && power_r == 0 && power_rc == 0
+                jac_type = "boozer";    @info "Recognized boozer jacobian from power exponents"
+            elseif power_b == 1 && power_bp == 0 && power_r == 0 && power_rc == 0
+                jac_type = "park";      @info "Recognized park jacobian from power exponents"
+            else
+                @info "Using manual jacobian exponents: power b, bp, r, rc = $(power_b), $(power_bp), $(power_r), $(power_rc)"
+            end
+        else
             error("Cannot recognize jac_type = $(jac_type)")
         end
         psihigh = min(psihigh, 1.0)
-        return new(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r,
+        return new(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
             grid_type, psilow, psihigh, mpsi, mtheta, newq0, etol,
             force_termination, use_galgrid)
     end

--- a/src/Equilibrium/InverseEquilibrium.jl
+++ b/src/Equilibrium/InverseEquilibrium.jl
@@ -204,7 +204,7 @@ function equilibrium_solver(input::InverseRunInput)
             spl_fs[itheta+1, 2] = f_deta
             spl_fs[itheta+1, 3] = r * jacfac
             spl_fs[itheta+1, 4] = spl_fs[itheta+1, 3] / (r * r)
-            spl_fs[itheta+1, 5] = spl_fs[itheta+1, 3] * bp^config.power_bp * b^config.power_b / r^config.power_r
+            spl_fs[itheta+1, 5] = spl_fs[itheta+1, 3] * bp^config.power_bp * b^config.power_b / (r^config.power_r * rfac^config.power_rc)
 
         end
         # c-----------------------------------------------------------------------

--- a/src/Equilibrium/InverseEquilibrium.jl
+++ b/src/Equilibrium/InverseEquilibrium.jl
@@ -227,7 +227,7 @@ function equilibrium_solver(input::InverseRunInput)
             spl_fs[itheta+1, 2] = f_deta
             spl_fs[itheta+1, 3] = r * jacfac
             spl_fs[itheta+1, 4] = spl_fs[itheta+1, 3] / (r * r)
-            spl_fs[itheta+1, 5] = spl_fs[itheta+1, 3] * bp^config.power_bp * b^config.power_b / (r^config.power_r * rfac^config.power_rc)
+            spl_fs[itheta+1, 5] = spl_fs[itheta+1, 3] * bp^config.power_bp * b^config.power_b / (r^config.power_r * max(rfac, eps(Float64))^config.power_rc)
 
         end
         # c-----------------------------------------------------------------------

--- a/src/Equilibrium/InverseEquilibrium.jl
+++ b/src/Equilibrium/InverseEquilibrium.jl
@@ -133,15 +133,38 @@ function equilibrium_solver(input::InverseRunInput)
     end
 
     # c-----------------------------------------------------------------------
-    # c     set up radial grid (only "ldp" implemented)
+    # c     set up radial grid
     # c-----------------------------------------------------------------------
-    if grid_type == "ldp"
+    if grid_type == "log_asymptotic"
+        if mpsi == 0 && config.psi_accuracy > 0
+            # Estimate A from q profile near psihigh (q is column 3 in sq_in)
+            ε = max(1.0 - psihigh, 0.001)
+            ψ₁ = clamp(1.0 - 3ε, psilow + 0.01, 0.999)
+            ψ₂ = clamp(1.0 - 1.5ε, psilow + 0.01, 0.999)
+            A = try
+                buf = zeros(size(sq_in.y, 2))
+                sq_in(buf, ψ₁); q1 = buf[3]
+                sq_in(buf, ψ₂); q2 = buf[3]
+                max(abs(q2 - q1) / log(2), 0.1)
+            catch
+                @warn "Could not estimate log slope from q profile, using default A=2.0"
+                2.0
+            end
+            mpsi = make_optimal_mpsi(psilow, psihigh, A; tau=config.psi_accuracy)
+        elseif mpsi == 0
+            mpsi = 128
+        end
+        sq_xs = make_optimal_psi_grid(psilow, psihigh, mpsi)
+    elseif grid_type == "ldp"
+        if mpsi == 0
+            mpsi = 128
+        end
         sq_xs = psilow .+ (psihigh - psilow) .* (sin.(range(0.0, 1.0; length=mpsi+1) .* (π/2))) .^ 2
-        sq_fs = zeros(Float64, mpsi+1, 4)
-        sq = cubic_interp(sq_xs, sq_fs; bc=CubicFit(), extrap=ExtendExtrap())
     else
-        error("Only 'ldp' grid_type is implemented for now.")
+        error("Unsupported grid_type: $grid_type")
     end
+    sq_fs = zeros(Float64, mpsi+1, 4)
+    sq = cubic_interp(sq_xs, sq_fs; bc=CubicFit(), extrap=ExtendExtrap())
 
     # c-----------------------------------------------------------------------
     # c     prepare new bicube type for coordinates.


### PR DESCRIPTION
## Summary

This branch delivers two major improvements to the direct equilibrium path (`efit` and `efit_arclength`), plus supporting benchmark infrastructure.

### 1. Arc-length robustness fix for `efit_arclength` (this branch)

**Problem**: `efit_arclength` produced spurious large-negative `et[1]` at 6 of 12 `psihigh` values tested (e.g., −4750 at ψ=0.996, −265 at ψ=0.997, −305 at ψ=0.998). Root cause: `Bp_floor = 1e-4 × Bp0` in the arc-length ODE biased the SFL angle integral `∫jac·dl/Bp_eff` near x-points, corrupting all near-separatrix rzphi splines.

**Fix** (`src/Equilibrium/DirectEquilibriumArcLength.jl`):
- **Bp_floor removed**: replaced `max(Bp, 1e-4 * Bp0)` with `max(Bp, eps(Float64))`. This allows `∫jac·dl/Bp` (dy[5]) to correctly diverge near x-points, giving proper SFL weight to the slow-field region. This was the root-cause fix.
- **Arc-length parameterization** (already in place): `dy[1:2] = (psiz, -psir)/|∇ψ|` so the tangent direction has no denominator singularity at x-points, unlike the geometric-angle ODE where `bz·cosη − br·sinη → 0`.
- **`abstol=1e20` for integrals** (dy[3:5]): prevents the solver from taking tiny steps due to fast-changing integrands near the x-point.
- `dy[5]` computes `jac·dl/Bp` directly in the ODE using the config's power values — no post-processing conversion needed.

**Results**:
| psihigh | Before | After |
|---------|--------|-------|
| 0.980 | −236 🔴 | +2.54 ✅ |
| 0.993 | −77 🔴 | +1.21 ✅ |
| 0.996 | −4750 🔴 | +1.25 ✅ |
| 0.997 | −265 🔴 | +1.02 ✅ |
| 0.9995 | −12.9 🔴 | +1.47 ✅ |
| 0.998 | −305 🔴 | −2219 ⚠️ (remaining, see below) |

q-profile max |Δq| vs `efit`: 6.3×10⁻⁴ < 1×10⁻³ ✅  
Roundtrip error: 5.2×10⁻⁵ < 1×10⁻⁴ ✅  
Runtime: 0.058 s (unchanged vs efit 0.056 s) ✅

---

### 2. Smart ψ grid packing: three-region `log_asymptotic` grid with auto-mpsi

**Problem**: The previous `ldp` (sin²) grid concentrates knots near ψ=1, but near a diverted tokamak separatrix q diverges logarithmically — q ~ −A·ln(1−ψ) — so the cubic spline error per interval grows as (1−ψ)⁻² unconditionally. The ldp grid gets *worse* accuracy per knot as psihigh → 1.

**Solution**: Three-region geometric grid that matches the actual smoothness of the solution in each zone:
- **Core** [psilow, 0.15]: geometric in log(ψ) — matches power-law axis behavior
- **Middle** [0.15, 0.95]: uniform in ψ — protects pedestal/bootstrap current resolution
- **Edge** [0.95, psihigh]: geometric in log(1−ψ) — exactly cancels the separatrix error growth

**Auto-mpsi** (new default `mpsi=0`): two probe field-line integrations near psihigh estimate the log slope A = |Δq|/ln(2) from actual geometry, then N is computed from a target accuracy `psi_accuracy=0.005`. Typical result: **~42 knots vs 128** for the ldp default, with better far-edge accuracy.

**New config fields** in `EquilibriumConfig`:
- `grid_type = "log_asymptotic"` (new default; `"ldp"` still valid)
- `mpsi = 0` (0 = auto-compute; any positive integer = fixed)
- `psi_accuracy = 0.005` (target absolute error in q for auto-mpsi)

**Benchmark results** (`equil_spline_comparison.jl` with log-scale zoom axes):

| psihigh | Auto-mpsi | q non-mono (edge) | efit vs arclength max\|Δq\| |
|---------|-----------|-------------------|------------------------------|
| 0.993   | 41        | 0 ✅              | < 1×10⁻³ ✅                 |
| 0.999   | 42        | 0 ✅              | < 1×10⁻³ ✅                 |
| 1.000   | 50        | 0 ✅ (efit/arc)   | < 1×10⁻³ ✅                 |

The edge zoom panel (q vs −ln(1−ψ)) confirms the asymptotic behavior: **q is linear**, with knot markers evenly spaced — exactly what the geometric grid produces. At psihigh=1.0, `efit_by_inversion` degrades (round-trip error 1.28e-1) due to contour-tracing accuracy near the X-point; `efit` and `efit_arclength` remain clean all the way to ψ=1.

---

### 3. `efit_by_inversion` improvements (from `direct_equilibrium_improvements`)

- Physics-based adaptive Cartesian grid for x-point region (β parameter scales with geometry)
- Default `resolution_factor` raised from 1.0 → 4.0
- Fixed theta convention, near-axis accuracy bugs, and Z-zoom grid β computation
- New `efit_arclength` and `efit_by_inversion` eq_type options added

---

### Benchmark infrastructure

- `equil_psihigh_scan.jl`: scans ψ_high from 0.980–1.0, reports et[1] for all three methods
- `equil_method_comparison.jl`: cross-method q-profile and roundtrip comparison
- `equil_spline_comparison.jl`: detailed per-profile plots with log(ψ) core zoom and −ln(1−ψ) edge zoom; scatter markers show actual knot positions in each coordinate

---

## Remaining action items

- **ψ=0.998 anomaly in `efit_arclength`**: One psihigh value (0.998) still gives et[1]=−2219 after the fix (0.997 and 0.999 are fine). Likely a near-marginal rational surface coincidence at that specific grid point. Investigate with finer psihigh resolution around 0.998.

## Test plan

- [x] Unit tests pass: `julia --project=. test/runtests.jl`
- [x] psihigh scan: `julia --project=. benchmarks/equil_psihigh_scan.jl`
- [x] Spline comparison at psihigh = 0.993, 0.999, 1.0: `julia --project=. benchmarks/equil_spline_comparison.jl examples/DIIID-like_ideal_example <psihigh>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)