### PR TITLE
EQUIL - Enforce Jordan-curve topology in efit_by_inversion flux surface tracing

### DIFF
--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -430,14 +430,12 @@ function equilibrium_solver_by_inversion(
         bv = Ctr.vertices(bbox_curve)
         r_bbox_lo, r_bbox_hi = extrema(v[1] for v in bv)
         z_bbox_lo, z_bbox_hi = extrema(v[2] for v in bv)
-        r_margin    = (r_bbox_hi - r_bbox_lo) * 0.05
-        z_span      = z_bbox_hi - z_bbox_lo
-        z_margin_lo = z_span * (topology ∈ (:sn_lower, :double_null) ? 0.12 : 0.05)
-        z_margin_hi = z_span * (topology ∈ (:sn_upper, :double_null) ? 0.12 : 0.05)
+        r_margin = (r_bbox_hi - r_bbox_lo) * 0.05
+        z_margin = (z_bbox_hi - z_bbox_lo) * 0.12
         r_lo = max(raw_profile.rmin, r_bbox_lo - r_margin)
         r_hi = min(raw_profile.rmax, r_bbox_hi + r_margin)
-        z_lo = max(raw_profile.zmin, z_bbox_lo - z_margin_lo)
-        z_hi = min(raw_profile.zmax, z_bbox_hi + z_margin_hi)
+        z_lo = max(raw_profile.zmin, z_bbox_lo - z_margin)
+        z_hi = min(raw_profile.zmax, z_bbox_hi + z_margin)
     else
         r_lo, r_hi = raw_profile.rmin, raw_profile.rmax
         z_lo, z_hi = raw_profile.zmin, raw_profile.zmax
@@ -613,22 +611,33 @@ function equilibrium_solver_by_inversion(
         @info "efit_by_inversion: $n_contour_success surfaces traced by global grid"
     end
 
-    # Area monotonicity check: shoelace areas should increase with ipsi.
-    # A decreasing area indicates a self-intersecting or mis-sorted contour.
-    prev_area = 0.0
-    for ipsi in 1:(mpsi + 1)
-        R_row = @view R_table[ipsi, :]
-        Z_row = @view Z_table[ipsi, :]
-        n_θ   = length(R_row)
-        area  = 0.0
-        @inbounds for k in 1:(n_θ - 1)
-            area += R_row[k] * Z_row[k + 1] - R_row[k + 1] * Z_row[k]
+    # Column-wise ρ monotonicity check: for each geometric angle θ_k, ρ = sqrt((R-ro)²+(Z-zo)²)
+    # must increase with ipsi (star-shaped nesting). Detects localized crossings that a global
+    # area check misses. Accumulates all violations and prints one consolidated warning.
+    n_violations = 0
+    first_ipsi = 0; first_k = 0
+    worst_Δρ = 0.0; worst_ipsi = 0; worst_k = 0
+    @inbounds for k in 1:(mtheta + 1)
+        ρ_prev = sqrt((R_table[1, k] - ro)^2 + (Z_table[1, k] - zo)^2)
+        for ipsi in 2:(mpsi + 1)
+            ρ = sqrt((R_table[ipsi, k] - ro)^2 + (Z_table[ipsi, k] - zo)^2)
+            if ρ < ρ_prev
+                n_violations += 1
+                if n_violations == 1
+                    first_ipsi = ipsi; first_k = k
+                end
+                Δρ = ρ_prev - ρ
+                if Δρ > worst_Δρ
+                    worst_Δρ = Δρ; worst_ipsi = ipsi; worst_k = k
+                end
+            end
+            ρ_prev = ρ
         end
-        area = abs(area) / 2
-        if area < prev_area
-            @warn "efit_by_inversion: area non-monotone at ipsi=$ipsi (area=$(@sprintf("%.4g", area)) < prev=$(@sprintf("%.4g", prev_area))); surface may be self-intersecting"
-        end
-        prev_area = area
+    end
+    if n_violations > 0
+        @warn "efit_by_inversion: ρ non-monotone at $n_violations (ipsi,θ) locations — adjacent surfaces may intersect. " *
+              "First: ipsi=$first_ipsi θ=$(@sprintf("%.3f", theta_grid[first_k])). " *
+              "Worst: ipsi=$worst_ipsi θ=$(@sprintf("%.3f", theta_grid[worst_k])) Δρ=$(@sprintf("%.3g", worst_Δρ)) m."
     end
 
     # Build InverseRunInput — same type consumed by equilibrium_solver(::InverseRunInput)

--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -615,20 +615,28 @@ function equilibrium_solver_by_inversion(
     # must increase with ipsi (star-shaped nesting). Detects localized crossings that a global
     # area check misses. Accumulates all violations and prints one consolidated warning.
     n_violations = 0
-    first_ipsi = 0; first_k = 0
-    worst_Δρ = 0.0; worst_ipsi = 0; worst_k = 0
-    @inbounds for k in 1:(mtheta + 1)
+    first_ipsi = 0
+    first_k = 0
+    worst_Δρ = 0.0
+    worst_ipsi = 0
+    worst_k = 0
+    # Iterate only 1:mtheta — column mtheta+1 is the periodic wrap of column 1 (θ=0≡θ=1)
+    # and would double-count any violation there.
+    @inbounds for k in 1:mtheta
         ρ_prev = sqrt((R_table[1, k] - ro)^2 + (Z_table[1, k] - zo)^2)
         for ipsi in 2:(mpsi + 1)
             ρ = sqrt((R_table[ipsi, k] - ro)^2 + (Z_table[ipsi, k] - zo)^2)
             if ρ < ρ_prev
                 n_violations += 1
                 if n_violations == 1
-                    first_ipsi = ipsi; first_k = k
+                    first_ipsi = ipsi
+                    first_k = k
                 end
                 Δρ = ρ_prev - ρ
                 if Δρ > worst_Δρ
-                    worst_Δρ = Δρ; worst_ipsi = ipsi; worst_k = k
+                    worst_Δρ = Δρ
+                    worst_ipsi = ipsi
+                    worst_k = k
                 end
             end
             ρ_prev = ρ

--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -24,26 +24,33 @@ function _is_closed_curve(curve)
 end
 
 """
-    _point_in_polygon_verts(verts, r_test, z_test)
+    _winding_number_verts(verts, r_test, z_test)
 
-Ray-casting point-in-polygon test on a `Ctr.vertices` vector.
+Winding number point-in-polygon test (Sunday algorithm) on a `Ctr.vertices` vector.
+Returns the signed winding count; nonzero means the test point is inside the polygon.
+More robust than ray-casting for near-collinear edges (e.g., surfaces near an x-point).
 """
-function _point_in_polygon_verts(verts, r_test::Float64, z_test::Float64)::Bool
+function _winding_number_verts(verts, r_test::Float64, z_test::Float64)::Int
     n = length(verts)
-    inside = false
+    wn = 0
     j = n
     @inbounds for i in 1:n
         ri, zi = verts[i]
         rj, zj = verts[j]
-        if (zi > z_test) != (zj > z_test)
-            r_cross = (rj - ri) * (z_test - zi) / (zj - zi) + ri
-            if r_test < r_cross
-                inside = !inside
+        if zj <= z_test
+            if zi > z_test
+                cross = (rj - r_test) * (zi - z_test) - (ri - r_test) * (zj - z_test)
+                cross > 0 && (wn += 1)
+            end
+        else
+            if zi <= z_test
+                cross = (rj - r_test) * (zi - z_test) - (ri - r_test) * (zj - z_test)
+                cross < 0 && (wn -= 1)
             end
         end
         j = i
     end
-    return inside
+    return wn
 end
 
 """
@@ -58,7 +65,7 @@ function select_plasma_contour(curve_list, ro::Float64, zo::Float64)
     for curve in curve_list
         _is_closed_curve(curve) || continue
         verts = Ctr.vertices(curve)
-        _point_in_polygon_verts(verts, ro, zo) && return curve
+        _winding_number_verts(verts, ro, zo) != 0 && return curve
     end
     return nothing
 end
@@ -97,8 +104,12 @@ end
 
 Resample a Contour.jl curve onto a uniform geometric-angle grid, writing results
 directly into the pre-allocated `R_out` and `Z_out` vectors (views into R_table/Z_table).
-Sorts vertices by geometric angle η, appends a periodic wrap point, fits cubic splines
-R(η) and Z(η), then samples at each `theta_grid` point.
+
+Uses a polar representation: fits a cubic spline on log ρ(η) where
+ρ_i = sqrt((R_i − ro)² + (Z_i − zo)²) and η_i = atan2(Z_i − zo, R_i − ro).
+This guarantees exp(logρ_spl) > 0 everywhere — a self-intersecting contour is
+impossible by construction — making it robust near x-points where R(η) and Z(η)
+splines tend to overshoot between widely-spaced knots.
 """
 function resample_contour_to_theta_grid!(
     R_out::AbstractVector{Float64}, Z_out::AbstractVector{Float64},
@@ -116,46 +127,39 @@ function resample_contour_to_theta_grid!(
         end
     end
 
-    # Compute angles and extract R/Z in a single pass
-    η_buf = Vector{Float64}(undef, nv)
-    R_buf = Vector{Float64}(undef, nv)
-    Z_buf = Vector{Float64}(undef, nv)
+    # Compute geometric angle η and log-radius logρ in one pass
+    η_buf   = Vector{Float64}(undef, nv)
+    logρ_buf = Vector{Float64}(undef, nv)
     @inbounds for i in 1:nv
         r, z = verts[i]
-        η_buf[i] = mod(atan(z - zo, r - ro), 2π)
-        R_buf[i] = r
-        Z_buf[i] = z
+        η_buf[i]   = mod(atan(z - zo, r - ro), 2π)
+        logρ_buf[i] = log(sqrt((r - ro)^2 + (z - zo)^2))
     end
 
     idx = sortperm(η_buf)
 
     # Build extended (nv+1) sorted arrays with periodic wrap appended
-    n_ext = nv + 1
-    η_ext = Vector{Float64}(undef, n_ext)
-    R_ext = Vector{Float64}(undef, n_ext)
-    Z_ext = Vector{Float64}(undef, n_ext)
+    n_ext   = nv + 1
+    η_ext   = Vector{Float64}(undef, n_ext)
+    logρ_ext = Vector{Float64}(undef, n_ext)
     @inbounds for i in 1:nv
         k = idx[i]
-        η_ext[i] = η_buf[k]
-        R_ext[i] = R_buf[k]
-        Z_ext[i] = Z_buf[k]
+        η_ext[i]   = η_buf[k]
+        logρ_ext[i] = logρ_buf[k]
     end
-    η_ext[n_ext] = η_ext[1] + 2π
-    R_ext[n_ext] = R_ext[1]
-    Z_ext[n_ext] = Z_ext[1]
+    η_ext[n_ext]   = η_ext[1] + 2π
+    logρ_ext[n_ext] = logρ_ext[1]
 
-    R_spl = cubic_interp(η_ext, R_ext; bc=PeriodicBC(), extrap=WrapExtrap(), search=LinearBinary())
-    Z_spl = cubic_interp(η_ext, Z_ext; bc=PeriodicBC(), extrap=WrapExtrap(), search=LinearBinary())
+    logρ_spl = cubic_interp(η_ext, logρ_ext; bc=PeriodicBC(), extrap=WrapExtrap(), search=LinearBinary())
 
-    # theta_grid is in turns [0, 1]; sample the geometric-angle spline at 2π*θ radians.
-    # Monotonically increasing → shared hint gives O(1) lookups per pass.
+    # theta_grid is in turns [0, 1]; sample at 2π*θ radians and convert polar → Cartesian.
+    # Monotonically increasing η → shared hint gives O(1) lookups per step.
     hint = Ref(1)
-    @inbounds for k in eachindex(theta_grid, R_out)
-        R_out[k] = R_spl(2π * theta_grid[k]; hint=hint)
-    end
-    hint[] = 1
-    @inbounds for k in eachindex(theta_grid, Z_out)
-        Z_out[k] = Z_spl(2π * theta_grid[k]; hint=hint)
+    @inbounds for k in eachindex(theta_grid, R_out, Z_out)
+        η = 2π * theta_grid[k]
+        ρ = exp(logρ_spl(η; hint=hint))
+        R_out[k] = ro + ρ * cos(η)
+        Z_out[k] = zo + ρ * sin(η)
     end
 end
 
@@ -426,12 +430,14 @@ function equilibrium_solver_by_inversion(
         bv = Ctr.vertices(bbox_curve)
         r_bbox_lo, r_bbox_hi = extrema(v[1] for v in bv)
         z_bbox_lo, z_bbox_hi = extrema(v[2] for v in bv)
-        r_margin = (r_bbox_hi - r_bbox_lo) * 0.05
-        z_margin = (z_bbox_hi - z_bbox_lo) * 0.05
+        r_margin    = (r_bbox_hi - r_bbox_lo) * 0.05
+        z_span      = z_bbox_hi - z_bbox_lo
+        z_margin_lo = z_span * (topology ∈ (:sn_lower, :double_null) ? 0.12 : 0.05)
+        z_margin_hi = z_span * (topology ∈ (:sn_upper, :double_null) ? 0.12 : 0.05)
         r_lo = max(raw_profile.rmin, r_bbox_lo - r_margin)
         r_hi = min(raw_profile.rmax, r_bbox_hi + r_margin)
-        z_lo = max(raw_profile.zmin, z_bbox_lo - z_margin)
-        z_hi = min(raw_profile.zmax, z_bbox_hi + z_margin)
+        z_lo = max(raw_profile.zmin, z_bbox_lo - z_margin_lo)
+        z_hi = min(raw_profile.zmax, z_bbox_hi + z_margin_hi)
     else
         r_lo, r_hi = raw_profile.rmin, raw_profile.rmax
         z_lo, z_hi = raw_profile.zmin, raw_profile.zmax
@@ -605,6 +611,24 @@ function equilibrium_solver_by_inversion(
         @info "efit_by_inversion: $(mpsi + 1 - n_zoom_surfaces) surfaces traced by global grid, $n_zoom_surfaces by zoomed core grid ($n_near_axis_fill below threshold + $(n_zoom_surfaces - n_near_axis_fill) overlap)"
     else
         @info "efit_by_inversion: $n_contour_success surfaces traced by global grid"
+    end
+
+    # Area monotonicity check: shoelace areas should increase with ipsi.
+    # A decreasing area indicates a self-intersecting or mis-sorted contour.
+    prev_area = 0.0
+    for ipsi in 1:(mpsi + 1)
+        R_row = @view R_table[ipsi, :]
+        Z_row = @view Z_table[ipsi, :]
+        n_θ   = length(R_row)
+        area  = 0.0
+        @inbounds for k in 1:(n_θ - 1)
+            area += R_row[k] * Z_row[k + 1] - R_row[k + 1] * Z_row[k]
+        end
+        area = abs(area) / 2
+        if area < prev_area
+            @warn "efit_by_inversion: area non-monotone at ipsi=$ipsi (area=$(@sprintf("%.4g", area)) < prev=$(@sprintf("%.4g", prev_area))); surface may be self-intersecting"
+        end
+        prev_area = area
     end
 
     # Build InverseRunInput — same type consumed by equilibrium_solver(::InverseRunInput)


### PR DESCRIPTION
## Background

The `efit_by_inversion` solver traces flux surface contours using Contour.jl (marching squares), then resamples each curve to a uniform-θ grid by fitting periodic cubic splines to R(θ) and Z(θ) independently. Benchmark figures showed that edge surfaces (high psihigh) are not always simple closed curves, manifesting as sporadic negative et[1] eigenvalues (e.g., −150 at psihigh=0.980, −44 at psihigh=0.993) even when roundtrip ψ error is low.

**Root cause**: The independently-fitted R(θ) and Z(θ) splines can overshoot between widely-spaced knots, especially near the X-point where contour vertices cluster in θ-angle but are widely separated in arc length. Even a small overshoot makes the interpolated curve self-intersecting. Every flux surface is a **Jordan curve that is star-shaped** with respect to the magnetic axis — a fact not previously exploited in the parameterization.

---

## What was done

### Change 1 — Primary: log ρ(θ) polar spline in `resample_contour_to_theta_grid!`

Instead of fitting R(θ) and Z(θ) separately, now fits a single periodic spline on **log ρ(θ)** where `ρ_i = sqrt((R_i − ro)² + (Z_i − zo)²)`.

```julia
logρ = logρ_spl(2π * θ)
R_out = ro + exp(logρ) * cos(2π * θ)
Z_out = zo + exp(logρ) * sin(2π * θ)
```

Since `exp(logρ_spl)` is strictly positive everywhere, a self-intersection (ρ → 0) is **impossible by construction** regardless of spline coefficients.

### Change 2 — Secondary: Winding number in `select_plasma_contour`

Replaced ray-casting (`_point_in_polygon_verts`) with the Sunday winding number algorithm (`_winding_number_verts`). More robust for near-collinear edges near x-points.

### Change 3 — Secondary: Uniform 12% bbox Z-margin

Changed from a topology-dependent asymmetric margin (12% on the X-point side, 5% on the other) to a uniform 12% on both sides. The asymmetry saved negligible grid points while adding non-obvious conditional logic.

```julia
r_margin = (r_bbox_hi - r_bbox_lo) * 0.05
z_margin = (z_bbox_hi - z_bbox_lo) * 0.12
```

### Change 4 — Validation: Column-wise ρ monotonicity check

After all surfaces are traced, checks that ρ = sqrt((R−ro)²+(Z−zo)²) is strictly increasing with ipsi at every geometric angle θ_k. This directly tests the star-shaped nesting condition and detects localized crossings that a shoelace area check misses (area growth is dominated by X-point flux expansion, not midplane crossings). All violations are accumulated and reported in a single consolidated `@warn` to avoid flooding the terminal.

---

## psihigh scan results (DIII-D-like, hamada coordinates)

The Jordan-curve fix eliminates spurious large-negative et[1] across psihigh 0.980–0.998, where `efit_arclength` had −236, −77, −4750, −264, −305:

| psihigh | efit_arclength | efit_by_inv (before) | efit_by_inv (after) |
|---------|---------------|----------------------|----------------------|
| 0.980 | −236 | −150 | **+2.21** ✓ |
| 0.993 | −77 | −44 | **+1.17** ✓ |
| 0.996 | −4750 | unstable | **+1.21** ✓ |
| 0.997–0.998 | −264, −305 | unstable | **+1.17, +1.14** ✓ |
| 0.9995+ | negative | negative | still negative |

---

## Insight: `equal_arc` is the natural coordinate system for `efit_by_inversion`

Investigation of the remaining negative et[1] at psihigh ≥ 0.9995 revealed a deeper issue in how `efit_by_inversion` interacts with the InverseEquilibrium SFL coordinate transform.

**The problem with `hamada` (or any non-equal-arc SFL):** `resample_contour_to_theta_grid!` samples flux surfaces at uniform *geometric* angle. InverseEquilibrium then performs a SFL remapping by integrating the Jacobian weight function. Near the separatrix, `B_pol → 0` at the X-point, causing the SFL weight to diverge there and compressing 90%+ of the SFL interval into the X-point region. This leaves very few spline knots to represent the rest of the surface, producing inaccurate metric coefficients, Jacobian, and q-profile at the boundary — directly corrupting the EL ODE coefficients and vacuum energy boundary term.

**Why `equal_arc` fixes this:** The equal_arc SFL coordinate advances θ proportional to geometric arc length — which is exactly what uniform geometric-angle sampling approximates. With `jac_type = "equal_arc"`, the SFL remapping inside InverseEquilibrium is nearly a no-op and the X-point compression problem disappears.

**Benchmark evidence** (psihigh=1.0, `efit_by_inv` vs `efit` reference):

| Metric | hamada | equal_arc |
|--------|--------|-----------|
| round-trip error | 1.09e-05 | **6.84e-06** |
| r² edge max\|Δ\| (θ=0.25) | 1.33e-01 | **6.05e-04** (220× better) |
| angle offset edge max\|Δ\| (θ=0.25) | 1.41e-01 | **2.29e-04** (616× better) |
| Jacobian edge max\|Δ\| | 5.29 | **0.28** (19× better) |
| \|B\| edge max\|Δ\| (θ=0.25) | 1.94e-01 | **1.94e-03** (100× better) |
| q(psihigh) error | ~10% | ~10% (unchanged — contour resolution issue, not coordinate system) |

---

## Files modified

| File | Change |
|------|--------|
| `src/Equilibrium/DirectEquilibriumByInversion.jl` | All four changes above |

---

## Remaining action items

- [ ] **Run psihigh scan with `equal_arc`** — expect significant improvement in et[1] at psihigh ≥ 0.9995 now that the Jacobian and metric errors are resolved
- [ ] **Consider making `equal_arc` the default `jac_type` for `efit_by_inversion`** (either automatically override or document as the recommended setting)
- [ ] **q(psihigh) accuracy at extreme psihigh** — remaining ~10% q error at psihigh≈1.0 is a contour-resolution issue; likely requires adaptive mtheta based on B_pol non-uniformity on the outermost surface
- [ ] **Regression tests**: Run `julia --project=. test/runtests.jl`
- [ ] **Review before merging** to `direct_equilibrium_improvements`

🤖 Generated with [Claude Code](https://claude.com/claude-code)