### PR TITLE
GITHUB ACTIONS - BUG FIX - Prevent duplicate Claude reviews on @claude review comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- `claude.yml` was matching any `@claude` mention, including `@claude review`, causing both workflows to fire and produce two independent bot reviews
- Added `!contains('@claude review')` exclusion to the three comment-based trigger conditions in `claude.yml`
- `@claude review` now routes exclusively to `claude-code-review.yml` (which has the structured review prompt and scoped tool permissions); all other `@claude` commands continue to route to `claude.yml`

## Test plan

- [ ] Comment `@claude review this pr` on a PR — verify only one review appears
- [ ] Comment `@claude what does this function do?` on a PR — verify `claude.yml` still responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)