### PR TITLE
PERTURBED EQUILIBRIUM - Coupling matrices and resonant vectors for singular coupling

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/benchmarks/benchmark_fortran.jl
+++ b/benchmarks/benchmark_fortran.jl
@@ -1,0 +1,573 @@
+#!/usr/bin/env julia
+"""
+benchmark_fortran.jl - Compare Julia GPEC results against Fortran GPEC reference outputs
+
+Reads Fortran output NetCDF files from a GPEC Fortran example directory, builds a
+matched Julia configuration, optionally runs Julia GPEC, then prints a side-by-side
+comparison table.
+
+# Usage
+
+```bash
+# Full run (creates bench dir, runs Julia, compares)
+julia --project=benchmarks benchmarks/benchmark_fortran.jl /path/to/DIIID_ideal_example --plot
+
+# Skip Julia re-run (use existing gpec.h5 in bench dir)
+julia --project=benchmarks benchmarks/benchmark_fortran.jl /path/to/DIIID_ideal_example --plot --skip-run
+```
+
+# Arguments
+
+- `fortran_dir`  : Path to Fortran example directory (contains equil.in, dcon.in, *.nc)
+- `--plot`       : Generate comparison plots (saved to bench dir)
+- `--skip-run`   : Skip running Julia GPEC (assume gpec.h5 already exists)
+
+# Outputs (written to bench dir)
+
+- `gpec.toml`            : Julia configuration matched to Fortran inputs
+- `forcing.dat`          : External forcing extracted from Phi_coil
+- `<eq_filename>`        : Copy of equilibrium file
+- `gpec.h5`              : Julia GPEC output (unless --skip-run)
+- `comparison_table.txt` : Side-by-side comparison (also printed to stdout)
+- `comparison_plots.png` : Plots (if --plot)
+"""
+
+using Dates
+using HDF5
+using NCDatasets
+using Plots
+using Printf
+using Statistics
+
+# ─── Argument parsing ────────────────────────────────────────────────────────
+
+function parse_args(args)
+    fortran_dir = ""
+    do_plot     = false
+    skip_run    = false
+    i = 1
+    while i <= length(args)
+        a = args[i]
+        if a == "--plot"
+            do_plot = true
+        elseif a == "--skip-run"
+            skip_run = true
+        elseif !startswith(a, "--")
+            fortran_dir = a
+        else
+            error("Unknown argument: $a")
+        end
+        i += 1
+    end
+    isempty(fortran_dir) && error("Usage: benchmark_fortran.jl <fortran_dir> [--plot] [--skip-run]")
+    return (fortran_dir=abspath(fortran_dir), do_plot=do_plot, skip_run=skip_run)
+end
+
+# ─── Fortran namelist parser ─────────────────────────────────────────────────
+
+"""
+    parse_namelist(filepath) -> Dict{String, String}
+
+Parse a Fortran namelist file (`&NAME ... /`) and return a flat dict of key→raw_value strings.
+Handles quoted strings, booleans (t/f), and numeric values.
+"""
+function parse_namelist(filepath::String)
+    text = read(filepath, String)
+    result = Dict{String, String}()
+    lines = split(text, '\n')
+    cleaned = join([split(l, '!')[1] for l in lines], "\n")
+    for m in eachmatch(r"(\w+)\s*=\s*(\"[^\"]*\"|[^=,/\n&]+?)(?=\s*(?:,|\n|\s+\w+\s*=|/))", cleaned)
+        key = lowercase(strip(m.captures[1]))
+        val = strip(m.captures[2])
+        if length(val) >= 2 && val[1] == '"' && val[end] == '"'
+            val = val[2:end-1]
+        end
+        isempty(key) || (result[key] = val)
+    end
+    return result
+end
+
+"""Extract a typed value from the namelist dict, with a default."""
+function nl_get(d::Dict, key::String, ::Type{String}, default="")
+    haskey(d, key) ? d[key] : default
+end
+function nl_get(d::Dict, key::String, ::Type{Float64}, default=0.0)
+    haskey(d, key) ? parse(Float64, d[key]) : default
+end
+function nl_get(d::Dict, key::String, ::Type{Int}, default=0)
+    haskey(d, key) ? parse(Int, d[key]) : default
+end
+function nl_get(d::Dict, key::String, ::Type{Bool}, default=false)
+    haskey(d, key) ? (lowercase(d[key]) in ("t", "true", ".true.")) : default
+end
+
+# ─── Load Fortran NC outputs ─────────────────────────────────────────────────
+
+"""Load Fortran outputs from the three NetCDF files in fortran_dir."""
+function load_fortran_outputs(fortran_dir::String, nn::Int)
+    dcon_file    = joinpath(fortran_dir, "dcon_output_n$(nn).nc")
+    profile_file = joinpath(fortran_dir, "gpec_profile_output_n$(nn).nc")
+    control_file = joinpath(fortran_dir, "gpec_control_output_n$(nn).nc")
+
+    isfile(dcon_file)    || error("Not found: $dcon_file")
+    isfile(profile_file) || error("Not found: $profile_file")
+    isfile(control_file) || error("Not found: $control_file")
+
+    fort = Dict{String,Any}()
+
+    NCDataset(dcon_file, "r") do ds
+        fort["psilim"] = Float64(ds.attrib["psilim"])
+        fort["qlim"]   = Float64(ds.attrib["qlim"])
+        fort["mlow"]   = Int(ds.attrib["mlow"])
+        fort["mhigh"]  = Int(ds.attrib["mhigh"])
+        fort["mpert"]  = Int(ds.attrib["mpert"])
+
+        fort["psi_n_dcon"] = Float64.(ds["psi_n"][:])
+        fort["q_dcon"]     = Float64.(ds["q"][:])
+        fort["di"]         = Float64.(ds["di"][:])
+        fort["dr"]         = Float64.(ds["dr"][:])
+        fort["m_vals"]     = Int.(ds["m"][:])
+
+        # W_t eigenvalues: NC dim (i=2, mode=34) → Julia (mode, i) = (34, 2)
+        wt_ev = Float64.(ds["W_t_eigenvalue"][:, :])
+        fort["W_t_eigenvalue"] = complex.(wt_ev[:, 1], wt_ev[:, 2])
+    end
+
+    NCDataset(profile_file, "r") do ds
+        fort["psi_n_rational"] = Float64.(ds["psi_n_rational"][:])
+        fort["q_rational"]     = Float64.(ds["q_rational"][:])
+
+        # Phi_res: NC dim (i=2, psi_n_rational=4) → Julia (psi_n_rational, i)
+        phi_res = Float64.(ds["Phi_res"][:, :])
+        fort["Phi_res"] = complex.(phi_res[:, 1], phi_res[:, 2])
+
+        delta = Float64.(ds["Delta"][:, :])
+        fort["Delta"] = complex.(delta[:, 1], delta[:, 2])
+
+        fort["w_isl"] = Float64.(ds["w_isl"][:])
+        fort["K_isl"] = Float64.(ds["K_isl"][:])
+    end
+
+    NCDataset(control_file, "r") do ds
+        # Phi_coil: NC dim (i=2, coil_index=3, m=34) → Julia (m, coil_index, i) = (34, 3, 2)
+        phi_coil = Float64.(ds["Phi_coil"][:, :, :])
+        amp_real = dropdims(sum(phi_coil[:, :, 1], dims=2), dims=2)
+        amp_imag = dropdims(sum(phi_coil[:, :, 2], dims=2), dims=2)
+        fort["Phi_coil_amp"] = complex.(amp_real, amp_imag)
+    end
+
+    return fort
+end
+
+# ─── Load Julia h5 outputs ───────────────────────────────────────────────────
+
+"""Load Julia GPEC outputs from gpec.h5."""
+function load_julia_outputs(h5_path::String)
+    isfile(h5_path) || error("Julia output not found: $h5_path")
+
+    julia = Dict{String,Any}()
+    h5open(h5_path, "r") do f
+        julia["psilim"] = read(f, "info/psilim")
+        julia["qlim"]   = read(f, "info/qlim")
+        julia["et"]     = read(f, "vacuum/et")
+        julia["psi_q"]  = read(f, "splines/profiles/xs")
+        julia["q"]      = read(f, "splines/profiles/q")
+        julia["di"]     = haskey(f, "locstab/di") ? read(f, "locstab/di") : Float64[]
+        julia["dr"]     = haskey(f, "locstab/dr") ? read(f, "locstab/dr") : Float64[]
+
+        sc = "perturbed_equilibrium/singular_coupling"
+        # New structure: [n_rational] vectors with matching metadata
+        julia["rational_psi"]        = haskey(f, "$sc/rational_psi")        ? read(f, "$sc/rational_psi")        : Float64[]
+        julia["rational_q"]          = haskey(f, "$sc/rational_q")          ? read(f, "$sc/rational_q")          : Float64[]
+        julia["rational_n"]          = haskey(f, "$sc/rational_n")          ? read(f, "$sc/rational_n")          : Int[]
+        julia["resonant_flux"]       = haskey(f, "$sc/resonant_flux")       ? read(f, "$sc/resonant_flux")       : ComplexF64[]
+        julia["island_half_width"]   = haskey(f, "$sc/island_half_width")   ? read(f, "$sc/island_half_width")   : Float64[]
+        julia["chirikov_parameter"]  = haskey(f, "$sc/chirikov_parameter")  ? read(f, "$sc/chirikov_parameter")  : Float64[]
+        julia["delta_prime"]         = haskey(f, "$sc/delta_prime")         ? read(f, "$sc/delta_prime")         : ComplexF64[]
+    end
+    return julia
+end
+
+# ─── Write bench_dir/forcing.dat ─────────────────────────────────────────────
+
+"""Write forcing.dat from Phi_coil amplitudes and m values."""
+function write_forcing_dat(filepath::String, n::Int, m_vals::Vector{Int}, amp::Vector{ComplexF64})
+    open(filepath, "w") do io
+        println(io, "# n  m  real(Phi_coil_sum)  imag(Phi_coil_sum)")
+        for (m, a) in zip(m_vals, amp)
+            @printf(io, "%4d  %4d  %+.8e  %+.8e\n", n, m, real(a), imag(a))
+        end
+    end
+end
+
+# ─── Write bench_dir/gpec.toml ───────────────────────────────────────────────
+
+"""Generate gpec.toml matched to Fortran equil.in and dcon.in parameters."""
+function write_gpec_toml(
+    filepath::String,
+    fortran_dir::String,
+    eq::Dict,
+    nn::Int,
+    dmlim::Float64, qlow::Float64, psiedge::Float64,
+    delta_mlow::Int, delta_mhigh::Int
+)
+    eq_type     = nl_get(eq, "eq_type",     String, "efit")
+    eq_filename = nl_get(eq, "eq_filename", String, "")
+    jac_type    = nl_get(eq, "jac_type",    String, "hamada")
+    grid_type   = nl_get(eq, "grid_type",   String, "ldp")
+    psilow      = nl_get(eq, "psilow",      Float64, 1e-4)
+    psihigh     = nl_get(eq, "psihigh",     Float64, 0.993)
+    mpsi        = nl_get(eq, "mpsi",        Int, 128)
+    mtheta      = nl_get(eq, "mtheta",      Int, 256)
+
+    open(filepath, "w") do io
+        println(io, "# Auto-generated by benchmark_fortran.jl")
+        println(io, "# Matched to Fortran run: $fortran_dir")
+        println(io)
+        println(io, "[Equilibrium]")
+        println(io, "eq_type     = \"$eq_type\"")
+        println(io, "eq_filename = \"$eq_filename\"")
+        println(io, "jac_type    = \"$jac_type\"")
+        println(io, "grid_type   = \"$grid_type\"")
+        @printf(io, "psilow      = %.4e\n", psilow)
+        @printf(io, "psihigh     = %.6f\n", psihigh)
+        println(io, "mpsi        = $mpsi")
+        println(io, "mtheta      = $mtheta")
+        println(io, "etol        = 1e-7")
+        println(io)
+        println(io, "[Wall]")
+        println(io, "shape = \"nowall\"")
+        println(io)
+        println(io, "[ForceFreeStates]")
+        println(io, "bal_flag = false")
+        println(io, "mat_flag = true")
+        println(io, "ode_flag = true")
+        println(io, "vac_flag = true")
+        println(io, "mer_flag = true")
+        println(io, "set_psilim_via_dmlim = true")
+        @printf(io, "dmlim    = %.4f\n", dmlim)
+        @printf(io, "qlow     = %.4f\n", qlow)
+        @printf(io, "psiedge  = %.4f\n", psiedge)
+        println(io, "nn_low   = $nn")
+        println(io, "nn_high  = $nn")
+        println(io, "delta_mlow  = $delta_mlow")
+        println(io, "delta_mhigh = $delta_mhigh")
+        println(io, "mthvac   = 512")
+        println(io, "eulerlagrange_tolerance = 1e-7")
+        println(io, "singfac_min = 1e-4")
+        println(io, "save_interval = 3")
+        println(io)
+        println(io, "[ForcingTerms]")
+        println(io, "forcing_data_file   = \"forcing.dat\"")
+        println(io, "forcing_data_format = \"ascii\"")
+        println(io)
+        println(io, "[PerturbedEquilibrium]")
+        println(io, "fixed_boundary          = false")
+        println(io, "compute_response        = true")
+        println(io, "compute_singular_coupling = true")
+        println(io, "verbose                 = true")
+        println(io, "write_outputs_to_HDF5   = true")
+    end
+end
+
+# ─── Comparison table ────────────────────────────────────────────────────────
+
+"""Format a relative percent difference string."""
+rel_pct(a, b) = abs(b) > 1e-30 ? @sprintf("%.1f%%", 100 * abs(a - b) / abs(b)) : "N/A"
+
+"""
+Find Julia row index for a given Fortran (q_int, nn).
+
+Matches on both n and q-integer from state.rational_n / state.rational_q.
+"""
+function find_julia_row(julia, q_int::Int, nn::Int)
+    rat_q = julia["rational_q"]
+    rat_n = julia["rational_n"]
+    isempty(rat_q) && return 0
+    for row in eachindex(rat_q)
+        row > length(rat_n) && break
+        if rat_n[row] == nn && round(Int, rat_q[row]) == q_int
+            return row
+        end
+    end
+    return 0
+end
+
+"""Print and return comparison table lines."""
+function build_comparison_table(fort, julia, fortran_dir, bench_dir, nn)
+    lines = String[]
+    push!(lines, "=" ^ 72)
+    push!(lines, "GPEC FORTRAN vs JULIA COMPARISON")
+    push!(lines, "=" ^ 72)
+    push!(lines, "Fortran : $fortran_dir")
+    push!(lines, "Julia   : $(joinpath(bench_dir, "gpec.h5"))")
+    push!(lines, "Date    : $(Dates.format(Dates.now(), "yyyy-mm-dd HH:MM"))")
+    push!(lines, "")
+
+    # ── Scalar parameters ──
+    push!(lines, "--- Scalar Parameters ---")
+    push!(lines, @sprintf("%-12s  %10s  %10s  %10s  %6s", "", "Fortran", "Julia", "AbsDiff", "Rel%"))
+    for (label, fv, jv) in [
+        ("psilim", fort["psilim"], julia["psilim"]),
+        ("qlim",   fort["qlim"],   julia["qlim"]),
+    ]
+        diff = abs(fv - jv)
+        push!(lines, @sprintf("%-12s  %10.6f  %10.6f  %10.6f  %6s", label, fv, jv, diff, rel_pct(fv, jv)))
+    end
+    push!(lines, "")
+
+    # ── W_t eigenvalue ──
+    push!(lines, "--- W_t Eigenvalue (least stable mode) ---")
+    push!(lines, @sprintf("%-8s  %10s  %10s  %6s", "", "Fortran", "Julia", "Rel%"))
+    f_wt = fort["W_t_eigenvalue"]
+    j_et = julia["et"]
+    fv = isempty(f_wt) ? NaN : f_wt[argmin(real.(f_wt))]
+    jv = isempty(j_et) ? NaN : j_et[1]
+    push!(lines, @sprintf("|W_t|    %10.4f  %10.4f  %6s", abs(fv), abs(jv), rel_pct(abs(fv), abs(jv))))
+    push!(lines, @sprintf("Re(W_t)  %10.4f  %10.4f  %6s", real(fv), real(jv), rel_pct(real(fv), real(jv))))
+    push!(lines, "")
+
+    # ── q profile RMS ──
+    push!(lines, "--- q Profile (RMS on common grid) ---")
+    fq_psi = fort["psi_n_dcon"]
+    fq     = fort["q_dcon"]
+    jq_psi = julia["psi_q"]
+    jq     = julia["q"]
+    if !isempty(jq) && !isempty(fq)
+        jq_on_fgrid = [_interp1(jq_psi, jq, p) for p in fq_psi]
+        rms = sqrt(mean((fq .- jq_on_fgrid).^2))
+        rms_rel = rms / mean(abs.(fq)) * 100
+        push!(lines, @sprintf("RMS(q_fort - q_julia) = %.5f  (%.2f%% relative)", rms, rms_rel))
+    else
+        push!(lines, "q profile unavailable")
+    end
+    push!(lines, "")
+
+    # ── Mercier criterion RMS ──
+    push!(lines, "--- Mercier Criterion ---")
+    fdi = fort["di"]
+    fdr = fort["dr"]
+    jdi = julia["di"]
+    jdr = julia["dr"]
+    if !isempty(jdi) && !isempty(fdi)
+        jdi_on_fg = [_interp1(jq_psi, jdi, p) for p in fq_psi]
+        jdr_on_fg = !isempty(jdr) ? [_interp1(jq_psi, jdr, p) for p in fq_psi] : fill(NaN, length(fq_psi))
+        rms_di = sqrt(mean((fdi .- jdi_on_fg).^2))
+        rms_dr = sqrt(mean((fdr .- jdr_on_fg).^2))
+        push!(lines, @sprintf("RMS(di_fort - di_julia) = %.5e", rms_di))
+        push!(lines, @sprintf("RMS(dr_fort - dr_julia) = %.5e", rms_dr))
+    else
+        push!(lines, "Mercier data unavailable")
+    end
+    push!(lines, "")
+
+    # ── Resonant surfaces ──
+    push!(lines, "--- Resonant Surface Comparison (n=$nn) ---")
+    push!(lines, @sprintf("%-4s  %-8s  %-8s  %-14s  %-14s  %-6s  %-10s  %-10s  %-6s  %-7s  %-7s  %-6s",
+        "q", "psi_fort", "psi_julia", "|Phi_res_fort|", "|Phi_res_julia|", "Rel%",
+        "w_isl_fort", "w_isl_julia", "Rel%", "K_fort", "K_julia", "Rel%"))
+
+    f_psi_rat = fort["psi_n_rational"]
+    f_q_rat   = fort["q_rational"]
+    f_phi_res = fort["Phi_res"]     # [n_surf] ComplexF64
+    f_w_isl   = fort["w_isl"]       # [n_surf] full island width
+    f_K_isl   = fort["K_isl"]       # [n_surf] Chirikov
+
+    j_rat_psi = julia["rational_psi"]    # [n_rational]
+    j_phi_res = julia["resonant_flux"]   # [n_rational] ComplexF64
+    j_ihw     = julia["island_half_width"]  # [n_rational]
+    j_chir    = julia["chirikov_parameter"] # [n_rational]
+
+    for (i, (fq_r, fp_r)) in enumerate(zip(f_q_rat, f_psi_rat))
+        q_int = round(Int, fq_r)
+        row = find_julia_row(julia, q_int, nn)
+
+        jp_r  = row > 0 && !isempty(j_rat_psi)  ? j_rat_psi[row]  : NaN
+        j_phi = row > 0 && !isempty(j_phi_res)  ? abs(j_phi_res[row]) : NaN
+        j_wisl= row > 0 && !isempty(j_ihw)      ? 2 * j_ihw[row]  : NaN
+        j_kch = row > 0 && !isempty(j_chir)     ? j_chir[row]     : NaN
+
+        f_phi  = abs(f_phi_res[i])
+        f_wisl = f_w_isl[i]
+        f_kch  = f_K_isl[i]
+
+        push!(lines, @sprintf(
+            "%-4d  %8.4f  %8s  %14.4e  %14s  %-6s  %10.4e  %10s  %-6s  %7.4f  %7s  %-6s",
+            q_int, fp_r,
+            isnan(jp_r)   ? "N/A" : @sprintf("%.4f", jp_r),
+            f_phi,
+            isnan(j_phi)  ? "N/A" : @sprintf("%.4e", j_phi),
+            isnan(j_phi)  ? "N/A" : rel_pct(f_phi, j_phi),
+            f_wisl,
+            isnan(j_wisl) ? "N/A" : @sprintf("%.4e", j_wisl),
+            isnan(j_wisl) ? "N/A" : rel_pct(f_wisl, j_wisl),
+            f_kch,
+            isnan(j_kch)  ? "N/A" : @sprintf("%.4f", j_kch),
+            isnan(j_kch)  ? "N/A" : rel_pct(f_kch, j_kch),
+        ))
+    end
+
+    push!(lines, "=" ^ 72)
+    return lines
+end
+
+"""Simple linear interpolation of y(x) at point xi."""
+function _interp1(x::AbstractVector, y::AbstractVector, xi::Real)
+    n = length(x)
+    n < 2 && return y[1]
+    xi <= x[1]   && return y[1]
+    xi >= x[end] && return y[end]
+    i = searchsortedlast(x, xi)
+    i = clamp(i, 1, n-1)
+    t = (xi - x[i]) / (x[i+1] - x[i])
+    return y[i] + t * (y[i+1] - y[i])
+end
+
+# ─── Plot generation ─────────────────────────────────────────────────────────
+
+function generate_plots(fort, julia, bench_dir, nn)
+    p1 = plot(fort["psi_n_dcon"], fort["q_dcon"], label="Fortran", xlabel="ψ_n", ylabel="q", title="q profile")
+    plot!(p1, julia["psi_q"], julia["q"], label="Julia", linestyle=:dash)
+
+    p2 = plot(fort["psi_n_dcon"], fort["di"], label="Fortran di", xlabel="ψ_n", ylabel="di", title="Mercier di")
+    !isempty(julia["di"]) && plot!(p2, julia["psi_q"], julia["di"], label="Julia di", linestyle=:dash)
+
+    p3 = plot(fort["psi_n_dcon"], fort["dr"], label="Fortran dr", xlabel="ψ_n", ylabel="dr", title="Mercier dr")
+    !isempty(julia["dr"]) && plot!(p3, julia["psi_q"], julia["dr"], label="Julia dr", linestyle=:dash)
+
+    f_wt = fort["W_t_eigenvalue"]
+    j_et = julia["et"]
+    fv   = isempty(f_wt) ? NaN : abs(f_wt[argmin(real.(f_wt))])
+    jv   = isempty(j_et) ? NaN : abs(j_et[1])
+    p4   = bar(["Fortran", "Julia"], [fv, jv], title="|W_t| least stable", ylabel="|W_t|", legend=false)
+
+    f_q_rat  = fort["q_rational"]
+    n_surf   = length(f_q_rat)
+    q_labels = [@sprintf("q≈%d", round(Int, q)) for q in f_q_rat]
+
+    f_phi_vals  = abs.(fort["Phi_res"])
+    j_phi_vals  = fill(NaN, n_surf)
+    j_wisl_vals = fill(NaN, n_surf)
+    j_kchir_vals= fill(NaN, n_surf)
+
+    for (i, fq_r) in enumerate(f_q_rat)
+        q_int = round(Int, fq_r)
+        row = find_julia_row(julia, q_int, nn)
+        if row > 0
+            !isempty(julia["resonant_flux"])      && (j_phi_vals[i]   = abs(julia["resonant_flux"][row]))
+            !isempty(julia["island_half_width"])  && (j_wisl_vals[i]  = 2 * julia["island_half_width"][row])
+            !isempty(julia["chirikov_parameter"]) && (j_kchir_vals[i] = julia["chirikov_parameter"][row])
+        end
+    end
+
+    p5 = groupedbar(
+        hcat(f_phi_vals, j_phi_vals),
+        xticks=(1:n_surf, q_labels),
+        label=["Fortran" "Julia"],
+        title="|Phi_res| per surface (n=$nn)", ylabel="|Phi_res|"
+    )
+
+    layout = @layout [a b c; d e]
+    p = plot(p1, p2, p3, p4, p5; layout=layout, size=(1400, 700))
+    outfile = joinpath(bench_dir, "comparison_plots.png")
+    savefig(p, outfile)
+    println("Plots saved to: ", abspath(outfile))
+end
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+function main(argv=ARGS)
+    opts = parse_args(argv)
+    fortran_dir = opts.fortran_dir
+    do_plot     = opts.do_plot
+    skip_run    = opts.skip_run
+
+    isdir(fortran_dir) || error("Fortran directory not found: $fortran_dir")
+
+    equil_file = joinpath(fortran_dir, "equil.in")
+    dcon_file  = joinpath(fortran_dir, "dcon.in")
+    isfile(equil_file) || error("equil.in not found in $fortran_dir")
+    isfile(dcon_file)  || error("dcon.in not found in $fortran_dir")
+
+    eq = parse_namelist(equil_file)
+    dc = parse_namelist(dcon_file)
+
+    nn          = nl_get(dc, "nn",          Int,     1)
+    delta_mlow  = nl_get(dc, "delta_mlow",  Int,     8)
+    delta_mhigh = nl_get(dc, "delta_mhigh", Int,     8)
+    dmlim       = nl_get(dc, "dmlim",       Float64, 0.2)
+    qlow        = nl_get(dc, "qlow",        Float64, 1.02)
+    psiedge     = nl_get(dc, "psiedge",     Float64, 1.0)
+    eq_filename = nl_get(eq, "eq_filename", String,  "")
+
+    println("Parsed Fortran inputs: nn=$nn, delta_mlow=$delta_mlow, delta_mhigh=$delta_mhigh")
+    println("  dmlim=$dmlim, qlow=$qlow, psiedge=$psiedge")
+    println("  eq_filename=$eq_filename")
+
+    println("\nLoading Fortran NetCDF outputs...")
+    fort = load_fortran_outputs(fortran_dir, nn)
+    println("  psilim=$(fort["psilim"]), qlim=$(fort["qlim"]), $(length(fort["psi_n_rational"])) rational surfaces")
+
+    bench_name = basename(fortran_dir) * "_resonant_response_benchmark"
+    bench_dir  = joinpath(homedir(), "Code", "benchmarks_for_gpec_fortran_to_julia", bench_name)
+    mkpath(bench_dir)
+    println("\nBenchmark directory: $bench_dir")
+
+    if !isempty(eq_filename)
+        src = joinpath(fortran_dir, eq_filename)
+        dst = joinpath(bench_dir, eq_filename)
+        if isfile(src) && !isfile(dst)
+            cp(src, dst)
+            println("Copied equilibrium file: $eq_filename")
+        end
+    end
+
+    forcing_path = joinpath(bench_dir, "forcing.dat")
+    write_forcing_dat(forcing_path, nn, fort["m_vals"], fort["Phi_coil_amp"])
+    println("Wrote forcing.dat ($(length(fort["m_vals"])) modes)")
+
+    toml_path = joinpath(bench_dir, "gpec.toml")
+    write_gpec_toml(toml_path, fortran_dir, eq, nn, dmlim, qlow, psiedge, delta_mlow, delta_mhigh)
+    println("Wrote gpec.toml")
+
+    h5_path = joinpath(bench_dir, "gpec.h5")
+    if skip_run
+        println("\n--skip-run: skipping Julia GPEC run")
+    else
+        println("\nRunning Julia GPEC (subprocess)...")
+        # Remove stale output so Julia doesn't append to old data
+        isfile(h5_path) && rm(h5_path)
+        gpec_root = joinpath(@__DIR__, "..")
+        julia_cmd = Base.julia_cmd()
+        cmd = `$julia_cmd --project=$gpec_root -e "using GeneralizedPerturbedEquilibrium; GeneralizedPerturbedEquilibrium.main([\"$bench_dir\"])"`
+        run(cmd)
+    end
+
+    println("\nLoading Julia outputs from $h5_path...")
+    julia = load_julia_outputs(h5_path)
+    println("  psilim=$(julia["psilim"]), qlim=$(julia["qlim"])")
+    n_rat = length(julia["rational_psi"])
+    println("  $n_rat resonant (surface, n) pairs found")
+
+    println()
+    table_lines = build_comparison_table(fort, julia, fortran_dir, bench_dir, nn)
+    for line in table_lines
+        println(line)
+    end
+
+    table_path = joinpath(bench_dir, "comparison_table.txt")
+    open(table_path, "w") do io
+        for line in table_lines
+            println(io, line)
+        end
+    end
+    println("\nComparison table saved to: ", abspath(table_path))
+
+    if do_plot
+        generate_plots(fort, julia, bench_dir, nn)
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -311,7 +311,7 @@ function main(args::Vector{String}=String[])
         if pe_ctrl.write_outputs_to_HDF5
             output_file = isempty(pe_ctrl.output_filename) ? ctrl.HDF5_filename : pe_ctrl.output_filename
             PerturbedEquilibrium.write_outputs_to_HDF5(
-                pe_state, pe_intr, pe_ctrl, joinpath(intr.dir_path, output_file)
+                pe_state, pe_intr, joinpath(intr.dir_path, output_file)
             )
             @info "Results written to $output_file"
         end

--- a/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
@@ -73,51 +73,61 @@ Response fields (mode space):
   - `xi_modes::Union{Nothing, NamedTuple}` - Displacement (psi, theta, zeta) [npsi, mpert]
   - `b_modes::Union{Nothing, NamedTuple}` - Magnetic field (psi, theta, zeta) [npsi, mpert]
 
-Singular coupling matrices [msing, numpert_total]:
-  - `resonant_flux::Matrix{ComplexF64}` - Resonant flux Φ_r/A (singcoup(1,:,:))
-  - `resonant_current::Matrix{ComplexF64}` - Resonant current (singcoup(2,:,:))
-  - `island_width_sq::Matrix{ComplexF64}` - (w/2)² in ψ_n (singcoup(3,:,:))
-  - `penetrated_field::Matrix{ComplexF64}` - Resonant field (singcoup(4,:,:))
-  - `delta_prime::Matrix{ComplexF64}` - Tearing stability Δ' (singcoup(5,:,:))
+Coupling matrices [n_rational × numpert_total] — one row per resonant (surface, n) pair.
+Each row maps the full applied field to the resonant response at that surface.
+Matches Fortran `C_f_x_out`, `C_i_x_out`, etc. (shape [mode_C, m_out]).
+  - `C_resonant_flux`    - Φ_r/A coupling (singcoup row 1)
+  - `C_resonant_current` - Resonant current coupling (singcoup row 2)
+  - `C_island_width_sq`  - (w/2)² coupling (singcoup row 3)
+  - `C_penetrated_field` - Penetrated field coupling (singcoup row 4)
+  - `C_delta_prime`      - Δ' coupling (singcoup row 5)
 
-Diagnostic quantities [msing]:
-  - `island_half_width::Vector{Float64}` - Actual w/2 (meters or ψ_n)
+Applied resonant vectors [n_rational] = C · forcing_amplitudes.
+Matches Fortran `Phi_res`, `w_isl`, `K_isl`, `Delta`.
+  - `resonant_flux`, `resonant_current`, `island_width_sq`, `penetrated_field`, `delta_prime`
+
+Diagnostics [n_rational]:
+  - `island_half_width::Vector{Float64}` - w/2 = sqrt(|island_width_sq|) from applied forcing
   - `chirikov_parameter::Vector{Float64}` - Island overlap metric
 
-Note: numpert_total = mpert × npert handles all (m,n) mode combinations
-
-Legacy fields (deprecated):
-  - `coupling_coefficient::ComplexF64` - Use singular coupling matrices instead
-  - `resonant_amplitude::Float64` - Use island diagnostics instead
+Metadata [n_rational] — identifies each (surface, n) row:
+  - `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
 
 Energies:
-  - `plasma_energy::Float64` - Plasma perturbation energy
-  - `vacuum_energy::Float64` - Vacuum perturbation energy
-  - `total_energy::Float64` - Total perturbation energy
+  - `plasma_energy`, `vacuum_energy`, `total_energy`
 """
 @kwdef mutable struct PerturbedEquilibriumState
-    # Response fields in mode space [npsi, mpert] following GPEC notation
-    # NamedTuples contain (psi, theta, zeta) components in flux coordinates
+    # Response fields in mode space [npsi, mpert]
     xi_modes::Union{Nothing, NamedTuple} = nothing
     b_modes::Union{Nothing, NamedTuple} = nothing
 
-    # Singular coupling matrices [msing × mpert] - GPEC singcoup(1:5,:,:)
-    resonant_flux::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)        # singcoup(1,:,:)
-    resonant_current::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)     # singcoup(2,:,:)
-    island_width_sq::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)      # singcoup(3,:,:)
-    penetrated_field::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)     # singcoup(4,:,:)
-    delta_prime::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)          # singcoup(5,:,:)
+    # Coupling matrices [n_rational × numpert_total]
+    C_resonant_flux::Matrix{ComplexF64}     = zeros(ComplexF64, 0, 0)
+    C_resonant_current::Matrix{ComplexF64}  = zeros(ComplexF64, 0, 0)
+    C_island_width_sq::Matrix{ComplexF64}   = zeros(ComplexF64, 0, 0)
+    C_penetrated_field::Matrix{ComplexF64}  = zeros(ComplexF64, 0, 0)
+    C_delta_prime::Matrix{ComplexF64}       = zeros(ComplexF64, 0, 0)
 
-    # Diagnostic quantities [msing]
-    island_half_width::Vector{Float64} = Float64[]     # Actual w/2 (meters or ψ_n)
-    chirikov_parameter::Vector{Float64} = Float64[]    # Island overlap
+    # Applied resonant vectors [n_rational] = C · amp_vec
+    resonant_flux::Vector{ComplexF64}       = ComplexF64[]
+    resonant_current::Vector{ComplexF64}    = ComplexF64[]
+    island_width_sq::Vector{ComplexF64}     = ComplexF64[]
+    penetrated_field::Vector{ComplexF64}    = ComplexF64[]
+    delta_prime::Vector{ComplexF64}         = ComplexF64[]
 
-    # Legacy singular coupling results (deprecated - use matrices above)
-    coupling_coefficient::ComplexF64 = 0.0 + 0.0im
-    resonant_amplitude::Float64 = 0.0
+    # Diagnostics [n_rational]
+    island_half_width::Vector{Float64}      = Float64[]
+    chirikov_parameter::Vector{Float64}     = Float64[]
+
+    # Metadata [n_rational]
+    rational_psi::Vector{Float64}           = Float64[]
+    rational_q::Vector{Float64}             = Float64[]
+    rational_m_res::Vector{Int}             = Int[]
+    rational_n::Vector{Int}                 = Int[]
+    rational_surface_idx::Vector{Int}       = Int[]
 
     # Energies
-    plasma_energy::Float64 = 0.0
-    vacuum_energy::Float64 = 0.0
-    total_energy::Float64 = 0.0
+    plasma_energy::Float64  = 0.0
+    vacuum_energy::Float64  = 0.0
+    total_energy::Float64   = 0.0
 end

--- a/src/PerturbedEquilibrium/SingularCoupling.jl
+++ b/src/PerturbedEquilibrium/SingularCoupling.jl
@@ -25,39 +25,24 @@ References:
         ctrl::PerturbedEquilibriumControl
     )
 
-Compute singular layer coupling metrics and island diagnostics.
+Compute singular layer coupling matrices and applied resonant vectors.
 
-Calculates the coupling between forcing modes and resonant surfaces, which determines
-the effectiveness of external perturbations at rational surfaces where q = m/n.
+Matching Fortran GPEC output: `C_f_x_out` (coupling matrix) and `Phi_res`, `w_isl`, etc. (applied vectors).
 [Park Phys. Plasmas 2009 056115]
-
-Implements GPEC algorithm from gpout.f:
-
- 1. For each forcing mode, apply unit field and compute plasma response
- 2. For each singular surface, evaluate field jump and compute coupling quantities
- 3. Calculate diagnostic island widths and overlap parameters
-
-## Arguments
-
-  - `state`: Output state structure to store results
-  - `equil`: Equilibrium solution with q-profile and flux surfaces
-  - `ForceFreeStates_results`: ForceFreeStates stability calculation results
-  - `vac_data`: Vacuum response data including Green's functions
-  - `ffs_intr`: ForceFreeStates internal state with singular surface data
-  - `intr`: PerturbedEquilibrium internal state with permeability matrix
-  - `ctrl`: Control parameters
 
 ## Modifies
 
-Populates the following fields in `state`:
+Populates `state` with:
 
-  - `resonant_flux[npert, msing]`: Normalized resonant flux Φ_r/A, indexed by (n-index, surface)
-  - `resonant_current[npert, msing]`: Resonant current density
-  - `island_width_sq[npert, msing]`: Square of island half-width (w/2)²
-  - `penetrated_field[npert, msing]`: Normal field at resonant surface
-  - `delta_prime[npert, msing]`: Tearing stability parameter Δ'
-  - `island_half_width[msing]`: Dimensional island half-width (maximum over all n)
-  - `chirikov_parameter[msing]`: Island overlap metric
+  Coupling matrices `[n_rational × numpert_total]` — C[row, j] = coupling when forcing mode j has unit amplitude:
+  - `C_resonant_flux`, `C_resonant_current`, `C_island_width_sq`, `C_penetrated_field`, `C_delta_prime`
+
+  Applied resonant vectors `[n_rational]` = C · amp_vec:
+  - `resonant_flux`, `resonant_current`, `island_width_sq`, `penetrated_field`, `delta_prime`
+
+  Diagnostics `[n_rational]`: `island_half_width`, `chirikov_parameter`
+
+  Metadata `[n_rational]`: `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
 """
 function compute_singular_coupling_metrics!(
     state::PerturbedEquilibriumState,
@@ -68,171 +53,151 @@ function compute_singular_coupling_metrics!(
     intr::PerturbedEquilibriumInternal,
     ctrl::PerturbedEquilibriumControl
 )
-    if ctrl.verbose
-        @info "Computing singular coupling metrics (GPEC method)"
-    end
+    ctrl.verbose && @info "Computing singular coupling metrics (GPEC method)"
 
-    # Extract dimensions
     msing = ffs_intr.msing
     mpert = ffs_intr.mpert
-    npert = ffs_intr.npert
     numpert_total = ffs_intr.numpert_total
 
     if msing == 0
-        if ctrl.verbose
-            @info "No singular surfaces found. Skipping singular coupling calculation."
-        end
+        ctrl.verbose && @info "No singular surfaces found. Skipping singular coupling calculation."
         return
     end
 
-    # Initialize output arrays [npert, msing]
-    # For single n: these collapse to [msing] vectors
-    # For multiple n: [npert, msing] matrices with zeros for non-resonant combinations
-    state.resonant_flux = zeros(ComplexF64, npert, msing)
-    state.resonant_current = zeros(ComplexF64, npert, msing)
-    state.island_width_sq = zeros(ComplexF64, npert, msing)
-    state.penetrated_field = zeros(ComplexF64, npert, msing)
-    state.delta_prime = zeros(ComplexF64, npert, msing)
-    state.island_half_width = zeros(Float64, msing)
-    state.chirikov_parameter = zeros(Float64, msing)
-
-    # Physical constants
-    chi1 = 2π * equil.psio  # Flux normalization
-    twopi = 2π
-    μ₀ = 4π * 1e-7
-
-    # Get permeability matrix from internal state
-    permeability = intr.plasma_response
-    if size(permeability, 1) == 0
+    if size(intr.plasma_response, 1) == 0
         @warn "Permeability matrix not computed. Skipping singular coupling."
         return
     end
 
-    # Get vacuum calculation parameters
-    mtheta = vac_data.mthvac  # Vacuum poloidal grid size
+    chi1 = 2π * equil.psio
+    twopi = 2π
+    mtheta = vac_data.mthvac
     mlow = ffs_intr.mlow
     nlow = ffs_intr.nlow
     nhigh = ffs_intr.nhigh
-
-    # Perturbed equilibrium calculations always use nowall
     wall_settings = Vacuum.WallShapeSettings(; shape="nowall")
 
-    if ctrl.verbose
-        nstr = nlow == nhigh ? "$nlow" : "$nlow:$nhigh"
-        @info "Computing surface Green's functions at $msing resonant surfaces (n = $nstr, no wall)"
-    end
-
-    # Main loop: Process each toroidal mode number separately
+    # Phase 1: Collect all resonant (surface, n) pairs in psi order
+    resonant_pairs = Tuple{Int,Int}[]
     for nn in nlow:nhigh
-        n_idx = nn - nlow + 1  # Index for storing in [npert, msing] arrays
-
-        if ctrl.verbose && npert > 1
-            @info "Computing metrics for n = $nn"
-        end
-
-        # For each singular surface, compute Green's functions for this n
-        # and calculate metrics if surface is resonant
         for s in 1:msing
-            sing_surf = ffs_intr.sing[s]
-
-            # Check if this surface is resonant for this n
-            # m_res = round(q * n) must be an integer and within our m range
-            m_res_float = sing_surf.q * nn
+            m_res_float = ffs_intr.sing[s].q * nn
             m_res = round(Int, m_res_float)
-
-            # Check if m/n is truly integer (within tolerance)
-            if abs(m_res_float - m_res) > 1e-6
-                # Not resonant for this n, leave metrics as zero
-                continue
-            end
-
-            # Check if resonant mode is within our m range
-            if m_res < ffs_intr.mlow || m_res > ffs_intr.mhigh
-                continue
-            end
-
-            # Compute Green's functions at this surface for this n
-            # TODO: This assumes an initial 2D equilibrum, getting 2D Green's functions for independent n
-            vac_input = Vacuum.VacuumInput(equil, sing_surf.psifac, mtheta, 1, mpert, mlow, 1, nn)
-            _, grri, grre, _, _ = Vacuum.compute_vacuum_response(vac_input, wall_settings; green_only=true)
-
-            # Store in singular surface struct (overwrites for each n)
-            ffs_intr.sing[s].grri = grri
-            ffs_intr.sing[s].grre = grre
-
-            # Find the linear index for the resonant mode (m_res, nn)
-            resnum = findfirst(j -> intr.m_modes[j] == m_res && intr.n_modes[j] == nn, 1:numpert_total)
-            if resnum === nothing
-                @warn "Could not find index for resonant mode (m=$m_res, n=$nn)" maxlog=1
-                continue
-            end
-
-            # Evaluate field derivative jump across surface
-            respsi = sing_surf.psifac
-            if size(ForceFreeStates_results.ca_l, 4) >= s && size(ForceFreeStates_results.ca_r, 4) >= s
-                # Use asymptotic coefficients from ideal MHD solution
-                # resnum is the resonant mode index, and we evaluate at forcing mode resnum
-                lbwp1 = ForceFreeStates_results.ca_l[resnum, resnum, 2, s]
-                rbwp1 = ForceFreeStates_results.ca_r[resnum, resnum, 2, s]
-            else
-                # Fallback: finite difference
-                spot = 1e-6
-                lpsi = respsi - spot / (abs(nn) * abs(sing_surf.q1))
-                rpsi = respsi + spot / (abs(nn) * abs(sing_surf.q1))
-                lbwp1 = interpolate_field_derivative(ForceFreeStates_results, lpsi, resnum, resnum)
-                rbwp1 = interpolate_field_derivative(ForceFreeStates_results, rpsi, resnum, resnum)
-            end
-
-            # Compute Delta' (tearing stability parameter)
-            delta_prime_val = (rbwp1 - lbwp1) / (twopi * chi1)
-            state.delta_prime[n_idx, s] = delta_prime_val
-
-            # Compute resonant current
-            j_c = compute_current_density(equil, sing_surf.psifac)
-            delcurs = (rbwp1 - lbwp1) * j_c * im / (twopi * m_res)
-            resonant_current_val = -delcurs / im
-            state.resonant_current[n_idx, s] = resonant_current_val
-
-            # Compute singular flux from current using surface inductance
-            singflx_mn = compute_singular_flux(
-                resonant_current_val,
-                vac_data,
-                ffs_intr,
-                intr,
-                sing_surf,
-                resnum,
-                nn
-            )
-
-            # Compute island half-width squared
-            shear = sing_surf.q1 * sing_surf.psifac / sing_surf.q
-            if abs(shear) > 1e-10
-                state.island_width_sq[n_idx, s] = 4.0 * singflx_mn / (twopi * shear * sing_surf.q * chi1)
-            else
-                state.island_width_sq[n_idx, s] = 0.0 + 0.0im
-            end
-
-            # Get interpolated field at resonant surface
-            interpbwn = interpolate_field_at_surface(ForceFreeStates_results, respsi, resnum, resnum, equil, m_res, nn)
-
-            # Normalize by surface area
-            area = compute_surface_area(equil, sing_surf.psifac)
-            state.penetrated_field[n_idx, s] = interpbwn / area
-            state.resonant_flux[n_idx, s] = singflx_mn / area
-
-            if ctrl.verbose && n_idx == 1 && s == 1
-                @info "Surface 1: q = $(@sprintf("%.3f", sing_surf.q)), ψ = $(@sprintf("%.3f", sing_surf.psifac)), m = $m_res, n = $nn, Δ' = $(@sprintf("%.3e", real(delta_prime_val)))"
-            end
+            abs(m_res_float - m_res) > 1e-6 && continue
+            (m_res < ffs_intr.mlow || m_res > ffs_intr.mhigh) && continue
+            push!(resonant_pairs, (s, nn))
         end
     end
 
-    # Post-processing: Compute diagnostic quantities
-    compute_island_diagnostics!(state, ffs_intr, equil, chi1, twopi)
+    n_rational = length(resonant_pairs)
+    if n_rational == 0
+        ctrl.verbose && @info "No resonant surfaces found. Skipping singular coupling."
+        return
+    end
+
+    ctrl.verbose && @info "Found $n_rational resonant (surface, n) pairs"
+
+    # Phase 2: Allocate output arrays
+    state.C_resonant_flux      = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_resonant_current   = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_island_width_sq    = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_penetrated_field   = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_delta_prime        = zeros(ComplexF64, n_rational, numpert_total)
+    state.rational_psi         = zeros(Float64, n_rational)
+    state.rational_q           = zeros(Float64, n_rational)
+    state.rational_m_res       = zeros(Int, n_rational)
+    state.rational_n           = zeros(Int, n_rational)
+    state.rational_surface_idx = zeros(Int, n_rational)
+
+    # Phase 3: Compute full coupling matrix rows
+    for (row, (s, nn)) in enumerate(resonant_pairs)
+        sing_surf = ffs_intr.sing[s]
+        m_res = round(Int, sing_surf.q * nn)
+
+        resnum = findfirst(j -> intr.m_modes[j] == m_res && intr.n_modes[j] == nn, 1:numpert_total)
+        if resnum === nothing
+            @warn "Could not find index for resonant mode (m=$m_res, n=$nn)" maxlog=1
+            continue
+        end
+
+        # Compute Green's functions at this surface for this n (once per pair)
+        vac_input = Vacuum.VacuumInput(equil, sing_surf.psifac, mtheta, 1, mpert, mlow, 1, nn)
+        _, grri_raw, grre_raw, _, _ = Vacuum.compute_vacuum_response(vac_input, wall_settings; green_only=true)
+        grri = Matrix{Float64}(grri_raw)
+        grre = Matrix{Float64}(grre_raw)
+        ffs_intr.sing[s].grri = grri
+        ffs_intr.sing[s].grre = grre
+
+        # Precompute L_surf; only the (m_res, m_res) diagonal element is needed for singflx
+        L_surf = compute_surface_inductance_from_greens(grri, grre, ffs_intr, intr)
+        m_idx = m_res - mlow + 1
+        L_mm = L_surf[m_idx, m_idx]
+
+        j_c   = compute_current_density(equil, sing_surf.psifac)
+        area  = compute_surface_area(equil, sing_surf.psifac)
+        shear = sing_surf.q1 * sing_surf.psifac / sing_surf.q
+
+        # Full coupling vector [numpert_total]: first index varies, second fixed at resnum
+        # jump_vec[j] = ca_r[j,resnum,2,s] - ca_l[j,resnum,2,s]  (Δ' of mode j via resonant column)
+        if size(ForceFreeStates_results.ca_l, 4) >= s && size(ForceFreeStates_results.ca_r, 4) >= s
+            jump_vec = ForceFreeStates_results.ca_r[:, resnum, 2, s] .-
+                       ForceFreeStates_results.ca_l[:, resnum, 2, s]
+        else
+            # Fallback: finite difference for diagonal entry only
+            jump_vec = zeros(ComplexF64, numpert_total)
+            spot = 1e-6
+            lpsi = sing_surf.psifac - spot / (abs(nn) * abs(sing_surf.q1))
+            rpsi = sing_surf.psifac + spot / (abs(nn) * abs(sing_surf.q1))
+            jump_vec[resnum] = interpolate_field_derivative(ForceFreeStates_results, rpsi, resnum, resnum) -
+                               interpolate_field_derivative(ForceFreeStates_results, lpsi, resnum, resnum)
+        end
+
+        state.C_delta_prime[row, :]      = jump_vec ./ (twopi * chi1)
+        state.C_resonant_current[row, :] = jump_vec .* (-j_c / (twopi * m_res))
+        state.C_resonant_flux[row, :]    = (L_mm / (twopi * nn * area)) .* state.C_resonant_current[row, :]
+        if abs(shear) > 1e-10
+            state.C_island_width_sq[row, :] = (4.0 / (twopi * shear * sing_surf.q * chi1)) .* state.C_resonant_flux[row, :]
+        end
+
+        # C_penetrated_field: loop required (reads u_store[resnum, j, ...] per forcing mode j)
+        for j in 1:numpert_total
+            state.C_penetrated_field[row, j] = interpolate_field_at_surface(
+                ForceFreeStates_results, sing_surf.psifac, resnum, j, equil, m_res, nn
+            ) / area
+        end
+
+        state.rational_psi[row]          = sing_surf.psifac
+        state.rational_q[row]            = sing_surf.q
+        state.rational_m_res[row]        = m_res
+        state.rational_n[row]            = nn
+        state.rational_surface_idx[row]  = s
+
+        if ctrl.verbose
+            dp_diag = real(state.C_delta_prime[row, resnum])
+            @info "Row $row: q=$(@sprintf("%.3f", sing_surf.q)), ψ=$(@sprintf("%.3f", sing_surf.psifac)), m=$m_res, n=$nn, Δ'(diag)=$(@sprintf("%.3e", dp_diag))"
+        end
+    end
+
+    # Phase 4: Apply forcing amplitudes → R = C · amp_vec
+    amp_vec = zeros(ComplexF64, numpert_total)
+    for mode in intr.forcing_modes
+        j = findfirst(k -> intr.m_modes[k] == mode.m && intr.n_modes[k] == mode.n, 1:numpert_total)
+        isnothing(j) || (amp_vec[j] = mode.amplitude)
+    end
+
+    state.resonant_flux    = state.C_resonant_flux    * amp_vec
+    state.resonant_current = state.C_resonant_current * amp_vec
+    state.island_width_sq  = state.C_island_width_sq  * amp_vec
+    state.penetrated_field = state.C_penetrated_field * amp_vec
+    state.delta_prime      = state.C_delta_prime      * amp_vec
+
+    # Phase 5: Island diagnostics from applied resonant vectors
+    compute_island_diagnostics!(state, n_rational)
 
     if ctrl.verbose
-        max_island_width = maximum(abs.(state.island_half_width))
-        max_delta_prime = maximum(abs.(real.(state.delta_prime)))
-        @info "Singular coupling complete. Max island half-width = $(@sprintf("%.3e", max_island_width)), max Δ' = $(@sprintf("%.3e", max_delta_prime))"
+        max_island = isempty(state.island_half_width) ? 0.0 : maximum(state.island_half_width)
+        max_dp     = isempty(state.delta_prime)       ? 0.0 : maximum(abs.(real.(state.delta_prime)))
+        @info "Singular coupling complete. Max island half-width = $(@sprintf("%.3e", max_island)), max |Δ'| = $(@sprintf("%.3e", max_dp))"
     end
 end
 
@@ -809,60 +774,31 @@ function compute_surface_area(
 end
 
 """
-    compute_island_diagnostics!(
-        state::PerturbedEquilibriumState,
-        ffs_intr::ForceFreeStatesInternal,
-        equil::Equilibrium.PlasmaEquilibrium,
-        chi1::Float64,
-        twopi::Float64
-    )
+    compute_island_diagnostics!(state::PerturbedEquilibriumState, n_rational::Int)
 
-Compute island half-width and Chirikov parameter for each singular surface.
+Compute island half-width and Chirikov parameter from applied resonant vectors.
 
-Uses the resonant flux and island_width_sq from singular coupling calculation.
+  - `island_half_width[row]` = √|island_width_sq[row]|
+  - `chirikov_parameter[row]` = half-width / (half-distance to nearest neighbor in rational_psi)
 """
-function compute_island_diagnostics!(
-    state::PerturbedEquilibriumState,
-    ffs_intr::ForceFreeStatesInternal,
-    equil::Equilibrium.PlasmaEquilibrium,
-    chi1::Float64,
-    twopi::Float64
-)
-    msing = ffs_intr.msing
+function compute_island_diagnostics!(state::PerturbedEquilibriumState, n_rational::Int)
+    state.island_half_width  = sqrt.(abs.(state.island_width_sq))
+    state.chirikov_parameter = zeros(Float64, n_rational)
 
-    # Compute island half-width for each singular surface
-    # Take maximum over all toroidal modes n
-    for s in 1:msing
-        sing_surf = ffs_intr.sing[s]
+    n_rational <= 1 && return
 
-        # Island half-width: w/2 = √|island_width_sq|
-        # Array is [npert, msing], so index with [:, s] to get all n for this surface
-        max_island_sq = maximum(abs.(state.island_width_sq[:, s]))
-        state.island_half_width[s] = sqrt(abs(max_island_sq))
-
-        # Compute Chirikov parameter: overlap = w/2 / distance_to_nearest_surface
-        # Find distance to nearest singular surface
-        if msing > 1
-            distances = Float64[]
-            for s2 in 1:msing
-                if s2 != s
-                    dist = abs(ffs_intr.sing[s].psifac - ffs_intr.sing[s2].psifac)
-                    push!(distances, dist)
-                end
-            end
-
-            if !isempty(distances)
-                hdist = minimum(distances) / 2.0  # Half-distance
-                if hdist > 1e-10
-                    state.chirikov_parameter[s] = state.island_half_width[s] / hdist
-                else
-                    state.chirikov_parameter[s] = Inf
-                end
-            else
-                state.chirikov_parameter[s] = 0.0
-            end
+    for row in 1:n_rational
+        psi_row  = state.rational_psi[row]
+        min_dist = Inf
+        for row2 in 1:n_rational
+            row2 == row && continue
+            dist = abs(state.rational_psi[row2] - psi_row)
+            min_dist = min(min_dist, dist)
+        end
+        if min_dist > 1e-10
+            state.chirikov_parameter[row] = state.island_half_width[row] / (min_dist / 2.0)
         else
-            state.chirikov_parameter[s] = 0.0
+            state.chirikov_parameter[row] = Inf
         end
     end
 end

--- a/src/PerturbedEquilibrium/Utils.jl
+++ b/src/PerturbedEquilibrium/Utils.jl
@@ -45,7 +45,6 @@ end
     write_outputs_to_HDF5(
         state::PerturbedEquilibriumState,
         intr::PerturbedEquilibriumInternal,
-        ctrl::PerturbedEquilibriumControl,
         filename::String
     )
 
@@ -58,15 +57,29 @@ perturbed_equilibrium/
 ├── forcing_modes/
 │   ├── n              # Toroidal mode numbers
 │   ├── m              # Poloidal mode numbers
-│   ├── amplitude_real # Real parts of forcing amplitudes
-│   └── amplitude_imag # Imaginary parts of forcing amplitudes
+│   └── amplitude      # ComplexF64 forcing amplitudes
 ├── response/
-│   ├── xi_perturbed   # Displacement field
-│   └── b_perturbed    # Magnetic field perturbation
+│   ├── xi_psi         # Displacement field (ComplexF64 [npsi, mpert])
+│   ├── b_psi          # Magnetic field (ComplexF64 [npsi, mpert])
+│   ├── b_theta
+│   └── b_zeta
 ├── singular_coupling/
-│   ├── coupling_coefficient_real
-│   ├── coupling_coefficient_imag
-│   └── resonant_amplitude
+│   ├── C_resonant_flux      # [n_rational × numpert_total] coupling matrix
+│   ├── C_resonant_current
+│   ├── C_island_width_sq
+│   ├── C_penetrated_field
+│   ├── C_delta_prime
+│   ├── resonant_flux        # [n_rational] applied vector = C · amp_vec
+│   ├── resonant_current
+│   ├── island_width_sq
+│   ├── penetrated_field
+│   ├── delta_prime
+│   ├── island_half_width    # [n_rational] Float64
+│   ├── chirikov_parameter
+│   ├── rational_psi         # [n_rational] surface metadata
+│   ├── rational_q
+│   ├── rational_m_res
+│   └── rational_n
 └── energies/
     ├── plasma_energy
     ├── vacuum_energy
@@ -76,54 +89,55 @@ perturbed_equilibrium/
 function write_outputs_to_HDF5(
     state::PerturbedEquilibriumState,
     intr::PerturbedEquilibriumInternal,
-    ctrl::PerturbedEquilibriumControl,
     filename::String
 )
-    h5open(filename, "cw") do file  # "cw" = create or read/write
-        # Create perturbed_equilibrium group
+    h5open(filename, "cw") do file
         pe_group = haskey(file, "perturbed_equilibrium") ? file["perturbed_equilibrium"] : create_group(file, "perturbed_equilibrium")
 
-        # Write forcing modes
+        # Forcing modes
         forcing_group = haskey(pe_group, "forcing_modes") ? pe_group["forcing_modes"] : create_group(pe_group, "forcing_modes")
-        n_modes = [mode.n for mode in intr.forcing_modes]
-        m_modes = [mode.m for mode in intr.forcing_modes]
-        amp_real = [real(mode.amplitude) for mode in intr.forcing_modes]
-        amp_imag = [imag(mode.amplitude) for mode in intr.forcing_modes]
+        forcing_group["n"]         = [mode.n for mode in intr.forcing_modes]
+        forcing_group["m"]         = [mode.m for mode in intr.forcing_modes]
+        forcing_group["amplitude"] = [mode.amplitude for mode in intr.forcing_modes]
 
-        forcing_group["n"] = n_modes
-        forcing_group["m"] = m_modes
-        forcing_group["amplitude_real"] = amp_real
-        forcing_group["amplitude_imag"] = amp_imag
-
-        # Write response fields; always write all entries, using empty arrays when not computed
+        # Response fields (ComplexF64 directly)
         response_group = haskey(pe_group, "response") ? pe_group["response"] : create_group(pe_group, "response")
-        have_xi   = !isnothing(state.xi_modes)
-        have_b    = have_xi && !isnothing(state.b_modes)
-        response_group["xi_psi_real"]  = have_xi ? real.(state.xi_modes.psi)   : Float64[]
-        response_group["xi_psi_imag"]  = have_xi ? imag.(state.xi_modes.psi)   : Float64[]
-        response_group["b_psi_real"]   = have_b  ? real.(state.b_modes.psi)    : Float64[]
-        response_group["b_psi_imag"]   = have_b  ? imag.(state.b_modes.psi)    : Float64[]
-        response_group["b_theta_real"] = have_b  ? real.(state.b_modes.theta)  : Float64[]
-        response_group["b_theta_imag"] = have_b  ? imag.(state.b_modes.theta)  : Float64[]
-        response_group["b_zeta_real"]  = have_b  ? real.(state.b_modes.zeta)   : Float64[]
-        response_group["b_zeta_imag"]  = have_b  ? imag.(state.b_modes.zeta)   : Float64[]
+        have_xi = !isnothing(state.xi_modes)
+        have_b  = have_xi && !isnothing(state.b_modes)
+        response_group["xi_psi"]  = have_xi ? state.xi_modes.psi   : ComplexF64[]
+        response_group["b_psi"]   = have_b  ? state.b_modes.psi    : ComplexF64[]
+        response_group["b_theta"] = have_b  ? state.b_modes.theta  : ComplexF64[]
+        response_group["b_zeta"]  = have_b  ? state.b_modes.zeta   : ComplexF64[]
 
-        # Write singular coupling metrics
+        # Singular coupling
         coupling_group = haskey(pe_group, "singular_coupling") ? pe_group["singular_coupling"] : create_group(pe_group, "singular_coupling")
-        coupling_group["coupling_coefficient_real"] = real(state.coupling_coefficient)
-        coupling_group["coupling_coefficient_imag"] = imag(state.coupling_coefficient)
-        coupling_group["resonant_amplitude"] = state.resonant_amplitude
 
-        # Write additional metrics
-        for (key, val) in intr.singular_coupling_metrics
-            coupling_group[key] = val
-        end
+        # Coupling matrices [n_rational × numpert_total]
+        !isempty(state.C_resonant_flux)    && (coupling_group["C_resonant_flux"]    = state.C_resonant_flux)
+        !isempty(state.C_resonant_current) && (coupling_group["C_resonant_current"] = state.C_resonant_current)
+        !isempty(state.C_island_width_sq)  && (coupling_group["C_island_width_sq"]  = state.C_island_width_sq)
+        !isempty(state.C_penetrated_field) && (coupling_group["C_penetrated_field"] = state.C_penetrated_field)
+        !isempty(state.C_delta_prime)      && (coupling_group["C_delta_prime"]      = state.C_delta_prime)
 
-        # Write energies
+        # Applied resonant vectors [n_rational]
+        !isempty(state.resonant_flux)      && (coupling_group["resonant_flux"]      = state.resonant_flux)
+        !isempty(state.resonant_current)   && (coupling_group["resonant_current"]   = state.resonant_current)
+        !isempty(state.island_width_sq)    && (coupling_group["island_width_sq"]    = state.island_width_sq)
+        !isempty(state.penetrated_field)   && (coupling_group["penetrated_field"]   = state.penetrated_field)
+        !isempty(state.delta_prime)        && (coupling_group["delta_prime"]        = state.delta_prime)
+        !isempty(state.island_half_width)  && (coupling_group["island_half_width"]  = state.island_half_width)
+        !isempty(state.chirikov_parameter) && (coupling_group["chirikov_parameter"] = state.chirikov_parameter)
+
+        # Metadata [n_rational]
+        !isempty(state.rational_psi)       && (coupling_group["rational_psi"]       = state.rational_psi)
+        !isempty(state.rational_q)         && (coupling_group["rational_q"]         = state.rational_q)
+        !isempty(state.rational_m_res)     && (coupling_group["rational_m_res"]     = state.rational_m_res)
+        !isempty(state.rational_n)         && (coupling_group["rational_n"]         = state.rational_n)
+
+        # Energies
         energy_group = haskey(pe_group, "energies") ? pe_group["energies"] : create_group(pe_group, "energies")
         energy_group["plasma_energy"] = state.plasma_energy
         energy_group["vacuum_energy"] = state.vacuum_energy
-        energy_group["total_energy"] = state.total_energy
+        energy_group["total_energy"]  = state.total_energy
     end
-
 end


### PR DESCRIPTION
## Summary

- **`PerturbedEquilibriumState`**: Replaces zero-padded `[npert, msing]` arrays and legacy `coupling_coefficient`/`resonant_amplitude` fields with dense `[n_rational × numpert_total]` coupling matrices (`C_resonant_flux`, `C_resonant_current`, `C_island_width_sq`, `C_penetrated_field`, `C_delta_prime`) and applied resonant vectors `[n_rational]` = C · amp_vec. Adds surface metadata arrays (`rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`). Matches Fortran GPEC's `C_f_x_out` / `Phi_res` output structure.
- **`SingularCoupling`**: Rewrites `compute_singular_coupling_metrics!` to collect all resonant (surface, n) pairs, compute full coupling rows using the off-diagonal `ca_l`/`ca_r` column (`jump_vec = ca_r[:,resnum,2,s] - ca_l[:,resnum,2,s]`), precompute `L_surf` once per pair, and apply forcing via `R = C * amp_vec`. Updates `compute_island_diagnostics!` for the new `[n_rational]` vector structure.
- **`Utils`**: Rewrites `write_outputs_to_HDF5` to write `ComplexF64` directly (no `_real`/`_imag` splits), write all `C_` matrices, applied vectors, and metadata. Removes unused `ctrl` parameter.
- **`benchmarks/benchmark_fortran.jl`**: New script comparing Julia vs Fortran GPEC outputs using Fortran NetCDF files; reads `rational_psi`/`rational_q` for surface matching, `resonant_flux` as `[n_rational]` vector.
- **`benchmarks/Project.toml`**: Separate benchmarks project for `NCDatasets` (benchmark-only dependency, not in main `Project.toml`).

## Test plan

- [ ] Run `benchmark_fortran.jl` against `DIIID_ideal_example` to confirm 4 resonant surfaces are found with matching ψ locations (`--skip-run` after first run)
- [ ] Verify `gpec.h5` structure: `perturbed_equilibrium/singular_coupling/` should contain `C_resonant_flux (4,34)`, `resonant_flux (4,)`, `rational_psi (4,)`, etc.
- [ ] Merge normalizations fix branch and re-run benchmark to confirm magnitudes converge toward Fortran reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)