### PR TITLE
EQUIL - BUG FIX - Fix kappa calculation in separatrix finder

### DIFF
--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -86,30 +86,23 @@ Performs the same function as equil_out_sep_find in the Fortran code.
 """
 function equilibrium_separatrix_find!(pe::PlasmaEquilibrium)
     mpsi = length(pe.rzphi_xs) - 1
-    mtheta = length(pe.rzphi_ys) - 1
-
-    vector = pe.rzphi_ys .+ @view pe.rzphi_offset.nodal_derivs.partials[1, end, :]
-
     edge_idx = mpsi + 1  # Edge flux surface index
     psi_edge = pe.rzphi_xs[edge_idx]
-    eta0 = 0.0
-    idx = findmin(abs.(vector .- eta0))[2]
-    theta = pe.rzphi_ys[idx]
     rsep = zeros(2)
 
+    # Outboard and inboard midplane R via bracketed Brent on θ + η(θ) - η₀ = 0.
+    # iside=1 → outboard (η₀=0.0, θ near 0),  iside=2 → inboard (η₀=0.5, θ near 0.5).
     for iside in 1:2
+        eta0 = (iside == 1) ? 0.0 : 0.5
         hint2d = (Ref(1), Ref(1))
+        theta_lo, theta_hi = (iside == 1) ? (-0.25, 0.25) : (0.25, 0.75)
         theta = find_zero(
-            (theta -> theta + pe.rzphi_offset((psi_edge, theta); hint=hint2d) - eta0,
-                theta -> 1.0 + pe.rzphi_offset((psi_edge, theta); deriv=DerivOp(0, 1), hint=hint2d)),
-            theta, Roots.Newton()
+            theta -> theta + pe.rzphi_offset((psi_edge, theta); hint=hint2d) - eta0,
+            (theta_lo, theta_hi), Roots.Brent()
         )
         r2 = pe.rzphi_rsquared((psi_edge, theta))
         offset = pe.rzphi_offset((psi_edge, theta))
         rsep[iside] = pe.ro + sqrt(r2) * cos(2π * (theta + offset))
-        eta0 = 0.5
-        idx = findmin(abs.(vector .- eta0))[2]
-        theta = pe.rzphi_ys[idx]
     end
 
     # Top and bottom separatrix Z extrema via bracketed Brent on ∂z/∂θ = 0.

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -112,25 +112,22 @@ function equilibrium_separatrix_find!(pe::PlasmaEquilibrium)
         theta = pe.rzphi_ys[idx]
     end
 
-    # Top and bottom separatrix locations using Newton iteration
+    # Top and bottom separatrix Z extrema via bracketed Brent on ∂z/∂θ = 0.
+    # iside=1 → bottom (θ ∈ [0.5, 1.0]),  iside=2 → top (θ ∈ [0.0, 0.5]).
+    # Splines use PeriodicBC + WrapExtrap, so θ outside [0,1] is valid.
     zsep = zeros(2)
     rext = zeros(2)
     zext = zeros(2)
 
     for iside in 1:2
-        eta0 = (iside == 1) ? 0.0 : 0.5
-        idx = findmin(abs.(vector .- eta0))[2]
-        theta = pe.rzphi_ys[idx]
         hint2d = (Ref(1), Ref(1))
 
-        # Cache variables that we need after convergence
+        # Cache variables populated by z_deriv, read after convergence
         rfac = Ref(0.0)
         cos_phase = Ref(0.0)
         z_val = Ref(0.0)
 
-        # Find θ where ∂z/∂θ = 0 (top/bottom separatrix extremum).
-        # z(θ) = zo + rfac·sin(2π(θ+η)), where rfac = √r²(θ) and η(θ) is the angular
-        # offset spline. We solve z1(θ) = 0 where z1 = ∂z/∂θ.
+        # ∂z/∂θ where z(θ) = zo + √r²(θ) · sin(2π(θ + η(θ)))
         function z_deriv(theta_inner)
             r2 = pe.rzphi_rsquared((psi_edge, theta_inner); hint=hint2d)
             r2y = pe.rzphi_rsquared((psi_edge, theta_inner); deriv=DerivOp(0, 1), hint=hint2d)
@@ -138,39 +135,20 @@ function equilibrium_separatrix_find!(pe::PlasmaEquilibrium)
             η1 = pe.rzphi_offset((psi_edge, theta_inner); deriv=DerivOp(0, 1), hint=hint2d)
             rfac_local = sqrt(max(0.0, r2))
             rfac1 = (rfac_local > 0) ? r2y / (2 * rfac_local) : 0.0
-            phase1 = 2π * (1 + η1)   # d[2π(θ+η)]/dθ
+            phase1 = 2π * (1 + η1)
             sin_phase = sin(2π * (theta_inner + η))
             cos_phase_local = cos(2π * (theta_inner + η))
 
-            # Cache values for later use
             rfac[] = rfac_local
             cos_phase[] = cos_phase_local
             z_val[] = pe.zo + rfac_local * sin_phase
 
-            return rfac_local * phase1 * cos_phase_local + rfac1 * sin_phase  # ∂z/∂θ
+            return rfac_local * phase1 * cos_phase_local + rfac1 * sin_phase
         end
 
-        function z_deriv2(theta_inner)
-            r2 = pe.rzphi_rsquared((psi_edge, theta_inner); hint=hint2d)
-            r2y = pe.rzphi_rsquared((psi_edge, theta_inner); deriv=DerivOp(0, 1), hint=hint2d)
-            r2yy = pe.rzphi_rsquared((psi_edge, theta_inner); deriv=DerivOp(0, 2), hint=hint2d)
-            η = pe.rzphi_offset((psi_edge, theta_inner); hint=hint2d)
-            η1 = pe.rzphi_offset((psi_edge, theta_inner); deriv=DerivOp(0, 1), hint=hint2d)
-            η2 = pe.rzphi_offset((psi_edge, theta_inner); deriv=DerivOp(0, 2), hint=hint2d)
-            rfac_local = sqrt(max(0.0, r2))
-            rfac1 = (rfac_local > 0) ? r2y / (2 * rfac_local) : 0.0
-            rfac2 = (rfac_local > 0) ? (r2yy - r2y * rfac1 / rfac_local) / (2 * rfac_local) : 0.0
-            phase1 = 2π * (1 + η1)   # d[2π(θ+η)]/dθ
-            phase2 = 2π * η2          # d²[2π(θ+η)]/dθ²
-            cos_phase_local = cos(2π * (theta_inner + η))
-            sin_phase = sin(2π * (theta_inner + η))
-
-            return (2 * rfac1 * phase1 + rfac_local * phase2) * cos_phase_local +
-                   (rfac2 - rfac_local * phase1^2) * sin_phase  # ∂²z/∂θ²
-        end
-
-        theta = find_zero((z_deriv, z_deriv2), theta, Roots.Newton();
-            atol=1e-12, rtol=1e-12, maxevals=1000)
+        theta_lo, theta_hi = (iside == 1) ? (0.5, 1.0) : (0.0, 0.5)
+        theta = find_zero(z_deriv, (theta_lo, theta_hi), Roots.Brent();
+            atol=1e-12, rtol=1e-12)
 
         rext[iside] = pe.ro + rfac[] * cos_phase[]
         zsep[iside] = zext[iside] = z_val[]

--- a/test/runtests_equil.jl
+++ b/test/runtests_equil.jl
@@ -350,4 +350,81 @@
             @test isfinite(dri.psio)
         end
     end
+
+    @testset "Separatrix geometry and kappa" begin
+        # Build a full Solovev equilibrium at sufficient resolution for the
+        # separatrix finder (equilibrium_separatrix_find!) to run.
+        #
+        # rsep[1] = outboard midplane R,  rsep[2] = inboard midplane R
+        # zsep[1] = bottom extremum Z,    zsep[2] = top extremum Z
+        # rext    = R at top/bottom extrema,  zext = zsep (identical)
+        # kappa   = (zsep[1] - zsep[2]) / (rsep[2] - rsep[1])  (elongation)
+
+        Eq = GeneralizedPerturbedEquilibrium.Equilibrium
+
+        function build_solovev_equilibrium(; e=1.6, a=0.33, r0=1.0, q0=1.9,
+                mpsi=64, mtheta=128)
+            eq_config = Eq.EquilibriumConfig(;
+                eq_type="sol", eq_filename="unused",
+                jac_type="pest", grid_type="ldp",
+                psilow=1e-4, psihigh=0.99999, mpsi=mpsi, mtheta=mtheta)
+            sol_config = Eq.SolovevConfig(64, 64, 64, e, a, r0, q0, 1.0, 1.0, 1.0)
+            dri = Eq.sol_run(eq_config, sol_config)
+            return Eq.equilibrium_solver(dri)
+        end
+
+        @testset "Elongated Solovev (e=1.6)" begin
+            pe = build_solovev_equilibrium(e=1.6)
+            rsep, zsep, rext, zext = Eq.equilibrium_separatrix_find!(pe)
+
+            # zsep[1] = bottom (negative Z), zsep[2] = top (positive Z)
+            @test zsep[1] < 0.0
+            @test zsep[2] > 0.0
+            @test zsep[1] < zsep[2]
+
+            # rsep[1] = outboard (R > R₀), rsep[2] = inboard (R < R₀)
+            @test rsep[1] > pe.ro
+            @test rsep[2] < pe.ro
+            @test rsep[1] > rsep[2]
+
+            # zext identical to zsep
+            @test zext ≈ zsep
+
+            # Up-down symmetry of Solovev: |zsep_bottom| ≈ |zsep_top|
+            @test abs(zsep[1]) ≈ abs(zsep[2]) rtol=0.01
+
+            # Extremum R should be near the magnetic axis
+            @test abs(rext[1] - pe.ro) < 0.2 * (rsep[1] - rsep[2])
+            @test abs(rext[2] - pe.ro) < 0.2 * (rsep[1] - rsep[2])
+
+            # kappa ≈ elongation
+            kappa = (zsep[1] - zsep[2]) / (rsep[2] - rsep[1])
+            @test kappa > 0
+            @test kappa ≈ 1.6 rtol=0.02
+        end
+
+        @testset "Circular Solovev (e=1.0)" begin
+            pe = build_solovev_equilibrium(e=1.0)
+            rsep, zsep, rext, zext = Eq.equilibrium_separatrix_find!(pe)
+
+            @test zsep[1] < 0.0
+            @test zsep[2] > 0.0
+            @test zsep[1] < zsep[2]
+            @test rsep[1] > rsep[2]
+
+            kappa = (zsep[1] - zsep[2]) / (rsep[2] - rsep[1])
+            @test kappa > 0
+            @test kappa ≈ 1.0 rtol=0.02
+        end
+
+        @testset "kappa via equilibrium_global_parameters!" begin
+            pe = build_solovev_equilibrium(e=1.6)
+            Eq.equilibrium_global_parameters!(pe)
+
+            @test pe.params.kappa > 0
+            @test pe.params.kappa ≈ 1.6 rtol=0.02
+            @test pe.params.zsep[1] < pe.params.zsep[2]
+            @test pe.params.rsep[1] > pe.params.rsep[2]
+        end
+    end
 end

--- a/test/runtests_equil.jl
+++ b/test/runtests_equil.jl
@@ -377,15 +377,24 @@
             pe = build_solovev_equilibrium(e=1.6)
             rsep, zsep, rext, zext = Eq.equilibrium_separatrix_find!(pe)
 
-            # zsep[1] = bottom (negative Z), zsep[2] = top (positive Z)
-            @test zsep[1] < 0.0
-            @test zsep[2] > 0.0
-            @test zsep[1] < zsep[2]
-
             # rsep[1] = outboard (R > R₀), rsep[2] = inboard (R < R₀)
             @test rsep[1] > pe.ro
             @test rsep[2] < pe.ro
             @test rsep[1] > rsep[2]
+
+            # rsep values consistent with r0=1.0, a=0.33 (Shafranov shift makes it approximate)
+            amean = (rsep[1] - rsep[2]) / 2
+            rmean = (rsep[1] + rsep[2]) / 2
+            @test amean ≈ 0.33 rtol=0.15
+            @test rmean ≈ 1.0 rtol=0.15
+
+            # rsep should be on the midplane (Z ≈ 0)
+            # (verified indirectly: R at η=0 and η=0.5 are midplane by definition)
+
+            # zsep[1] = bottom (negative Z), zsep[2] = top (positive Z)
+            @test zsep[1] < 0.0
+            @test zsep[2] > 0.0
+            @test zsep[1] < zsep[2]
 
             # zext identical to zsep
             @test zext ≈ zsep
@@ -407,10 +416,16 @@
             pe = build_solovev_equilibrium(e=1.0)
             rsep, zsep, rext, zext = Eq.equilibrium_separatrix_find!(pe)
 
+            @test rsep[1] > pe.ro
+            @test rsep[2] < pe.ro
+            @test rsep[1] > rsep[2]
+
             @test zsep[1] < 0.0
             @test zsep[2] > 0.0
             @test zsep[1] < zsep[2]
-            @test rsep[1] > rsep[2]
+
+            # For circular cross-section, rext[1] ≈ rext[2] (top/bottom at same R)
+            @test rext[1] ≈ rext[2] rtol=0.01
 
             kappa = (zsep[1] - zsep[2]) / (rsep[2] - rsep[1])
             @test kappa > 0


### PR DESCRIPTION
## Summary

`equilibrium_separatrix_find!` used unbounded Newton to find separatrix geometry. Without bracket constraints, Newton frequently diverged — θ escaped to values like ±1e2 or larger. Due to `sin`/`cos` periodicity, the diverged θ still returned plausible values, but which extremum it landed on depended on spline coefficients and grid resolution. When both sides landed on the same extremum, `kappa ≈ 0` or `kappa < 0`.

## Fix

Replace all Newton calls in `equilibrium_separatrix_find!` with bracketed Brent:
- **zsep** (top/bottom Z extrema): Brent on `dZ/dθ = 0`, θ ∈ [0.5, 1.0] (bottom) / [0.0, 0.5] (top). Removes `z_deriv2` entirely.
- **rsep** (outboard/inboard midplane R): Brent on `θ + η(θ) - η₀ = 0`, θ ∈ [-0.25, 0.25] (outboard) / [0.25, 0.75] (inboard). Removes derivative-based Newton step.

Adds regression tests for kappa and separatrix geometry with Solovev equilibria (e=1.6, e=1.0).

## Performance (zsep loop, `@btime`)

| | Newton (old) | Brent (new) |
|---|---|---|
| iside=1 (bottom) | 3.1 μs, 11 allocs (5.2 KiB) | 1.0 μs, 5 allocs (80 B) |
| iside=2 (top) | 2.9 μs, 11 allocs (5.2 KiB) | 1.8 μs, 5 allocs (80 B) |

No `d²Z/dθ²` computation and fewer iterations within the bracket.
