### PR TITLE
CI - NEW FEATURE - Add auto-merge workflow triggered by PR label

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,33 @@
+name: Auto-Merge
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge
+    if: github.event.action == 'labeled' && github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+
+  disable-auto-merge:
+    name: Disable auto-merge
+    if: github.event.action == 'unlabeled' && github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --disable-auto "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that enables auto-merge (squash) when a PR targeting `main` or `develop` is labeled `auto-merge`
- Removing the label disables auto-merge
- Uses GitHub's built-in `gh pr merge --auto` — no polling or custom merge logic

## Prerequisites (repo settings)

Before this workflow will function, two settings must be configured:

1. **Enable auto-merge**: Settings > General > Pull Requests > check "Allow auto-merge"
2. **Add branch protection rules** for `main` and `develop` with required status checks:
   - `runtests lts - ubuntu-latest`
   - `runtests 1.11 - ubuntu-latest`
   - `runtests 1.x - ubuntu-latest`
   - (optionally `Documentation`)

## Behavior

| Scenario | What happens |
|---|---|
| Label added, tests pass | PR merges automatically (squash) |
| Label added, tests fail | Waits; merges on next push if tests pass |
| Merge conflicts | GitHub cancels auto-merge, posts comment |
| Label removed | Auto-merge disabled |

## Test plan

- [x] Enable "Allow auto-merge" in repo settings
- [x] Add branch protection rules with required status checks
- [x] Merge this PR, then test on a subsequent PR by adding the `auto-merge` label
- [ ] Confirm PR timeline shows "auto-merge enabled" and PR merges after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)