### PR TITLE
PerturbedEquilibrium - PERFORMANCE - Coarse-grid rzphi geometry in field reconstruction

### DIFF
--- a/src/PerturbedEquilibrium/FieldReconstruction.jl
+++ b/src/PerturbedEquilibrium/FieldReconstruction.jl
@@ -153,11 +153,15 @@ function reconstruct_physical_fields(
     # R,Z,φ cylindrical components (Fortran gpeq_rzphi)
     # ξ: uses J-weighted psi (xwp from gpeq_contra) and regularized theta (xmt)
     # b: uses raw psi (bwp from gpeq_sol, no Jacobian convolution) and regularized theta (bmt)
+    # Build the (ψ,θ) flux→cylindrical geometry once and reuse it for both ξ and b: the
+    # transform matrices depend only on equilibrium geometry, not on the perturbed field.
     mlow = ffs_intr.mlow
-    xi_R, xi_Z, xi_phi = _compute_rzphi_modes(
-        equil, psi_grid, mlow, size(xi_psi_modes, 2), xwp_modes, xmt_modes, xvz_modes)
-    b_R, b_Z, b_phi = _compute_rzphi_modes(
-        equil, psi_grid, mlow, size(b_psi_modes, 2), b_psi_modes, b_theta_reg, bvz_modes)
+    mpert_rz = size(xi_psi_modes, 2)
+    mtheta_rz = max(2 * (abs(mlow) + mpert_rz), 512)
+    ft_rz = Utilities.FourierTransforms.FourierTransform(mtheta_rz, mpert_rz, mlow)
+    rzphi_geom = _build_rzphi_geometry(equil, psi_grid, mtheta_rz)
+    xi_R, xi_Z, xi_phi = _apply_rzphi_transform(rzphi_geom, ft_rz, mtheta_rz, xwp_modes, xmt_modes, xvz_modes)
+    b_R, b_Z, b_phi = _apply_rzphi_transform(rzphi_geom, ft_rz, mtheta_rz, b_psi_modes, b_theta_reg, bvz_modes)
 
     xi_modes = (
         psi   = xi_psi_modes,
@@ -808,75 +812,36 @@ function compute_b_n_xi_n_modes(
 end
 
 """
-    _compute_rzphi_modes(equil, psi_grid, mlow, mpert,
-        psi_input, theta_input, cova_zeta_input) -> (R_modes, Z_modes, phi_modes)
+    _build_rzphi_geometry(equil, psi_grid, mtheta) -> NamedTuple of [mtheta, npsi] arrays
 
-Convert mode-space perturbation from flux coordinates (ψ,θ,ζ) to cylindrical (R,Z,φ).
+Build the (ψ,θ) flux→cylindrical transformation geometry on the DFT θ grid: the
+transformation matrix entries t11/t12/t21/t22/t33 and the Jacobian J_theta, as
+`[mtheta, npsi]` arrays (one column per flux surface).
 
-Implements Fortran `gpeq_rzphi` (gpeq.f:439-501):
-    R(θ)   = (t11·psi_input + t12·theta_input) / J
-    Z(θ)   = (t21·psi_input + t22·theta_input) / J
-    φ(θ)   = t33 · cova_zeta_input
-
-Returns mode-space arrays (npsi × mpert) in SFL coordinates. The pointwise product with
-geometry generates harmonics beyond mpert; users needing fuller resolution should increase
-the mode count or use `Analysis.PerturbedEquilibriumModes.modes_to_theta` post-hoc.
-
-The caller passes different inputs for ξ vs b (see `reconstruct_physical_fields`).
+These depend only on equilibrium geometry, not on the perturbed field, so they are computed
+once and reused for both the ξ and b reconstructions (Fortran gpeq.f:458-475).
 """
-function _rzphi_workspace(mtheta::Int)
-    return (
-        R_fun=zeros(ComplexF64, mtheta),
-        Z_fun=zeros(ComplexF64, mtheta),
-        phi_fun=zeros(ComplexF64, mtheta),
-        t11=Vector{Float64}(undef, mtheta),
-        t12=Vector{Float64}(undef, mtheta),
-        t21=Vector{Float64}(undef, mtheta),
-        t22=Vector{Float64}(undef, mtheta),
-        t33=Vector{Float64}(undef, mtheta),
-        J_theta=Vector{Float64}(undef, mtheta),
-        hint=(Ref(1), Ref(1))
-    )
-end
-
-function _compute_rzphi_modes(
+function _build_rzphi_geometry(
     equil::Equilibrium.PlasmaEquilibrium,
     psi_grid::Vector{Float64},
-    mlow::Int, mpert::Int,
-    psi_input::Matrix{ComplexF64},
-    theta_input::Matrix{ComplexF64},
-    cova_zeta_input::Matrix{ComplexF64}
+    mtheta::Int
 )
     npsi = length(psi_grid)
     R0 = equil.ro
 
-    # Theta grid for DFT — matches Fortran mthsurf
-    mtheta = max(2 * (abs(mlow) + mpert), 512)
-    ft = Utilities.FourierTransforms.FourierTransform(mtheta, mpert, mlow)
+    t11 = Matrix{Float64}(undef, mtheta, npsi)
+    t12 = Matrix{Float64}(undef, mtheta, npsi)
+    t21 = Matrix{Float64}(undef, mtheta, npsi)
+    t22 = Matrix{Float64}(undef, mtheta, npsi)
+    t33 = Matrix{Float64}(undef, mtheta, npsi)
+    J_theta = Matrix{Float64}(undef, mtheta, npsi)
 
-    R_modes   = zeros(ComplexF64, npsi, mpert)
-    Z_modes   = zeros(ComplexF64, npsi, mpert)
-    phi_modes = zeros(ComplexF64, npsi, mpert)
-
-    # Per-thread theta-space workspaces; the immutable `ft` functor is shared read-only.
-    ws_bufs = [_rzphi_workspace(mtheta) for _ in 1:Threads.maxthreadid()]
+    hints = [(Ref(1), Ref(1)) for _ in 1:Threads.maxthreadid()]
 
     Threads.@threads :static for ipsi in 1:npsi
-        w = ws_bufs[Threads.threadid()]
-        R_fun = w.R_fun
-        Z_fun = w.Z_fun
-        phi_fun = w.phi_fun
-        t11 = w.t11
-        t12 = w.t12
-        t21 = w.t21
-        t22 = w.t22
-        t33 = w.t33
-        J_theta = w.J_theta
-        hint = w.hint
-
+        hint = hints[Threads.threadid()]
         psi = psi_grid[ipsi]
 
-        # Compute transformation matrix at each theta point (Fortran gpeq.f:458-475)
         for itheta in 1:mtheta
             theta = (itheta - 1) / mtheta  # SFL theta ∈ [0, 1)
             pt = (psi, theta)
@@ -904,13 +869,55 @@ function _compute_rzphi_modes(
                 v11 = 0.0; v12 = 0.0; v21 = 0.0; v22 = 0.0
             end
 
-            t11[itheta] = c * v11 - s * v12
-            t12[itheta] = c * v21 - s * v22
-            t21[itheta] = s * v11 + c * v12
-            t22[itheta] = s * v21 + c * v22
-            t33[itheta] = -1.0 / (2π * R_here)
-            J_theta[itheta] = jac
+            t11[itheta, ipsi] = c * v11 - s * v12
+            t12[itheta, ipsi] = c * v21 - s * v22
+            t21[itheta, ipsi] = s * v11 + c * v12
+            t22[itheta, ipsi] = s * v21 + c * v22
+            t33[itheta, ipsi] = -1.0 / (2π * R_here)
+            J_theta[itheta, ipsi] = jac
         end
+    end
+
+    return (; t11, t12, t21, t22, t33, J_theta)
+end
+
+"""
+    _apply_rzphi_transform(geom, ft, mtheta, psi_input, theta_input, cova_zeta_input)
+        -> (R_modes, Z_modes, phi_modes)
+
+Apply a prebuilt `_build_rzphi_geometry` cache to one perturbed field, converting it from
+flux coordinates (ψ,θ,ζ) to cylindrical (R,Z,φ) in mode space (Fortran `gpeq_rzphi`):
+
+    R(θ) = (t11·ξ^ψ + t12·ξ^θ) / J,  Z(θ) = (t21·ξ^ψ + t22·ξ^θ) / J,  φ(θ) = t33·ξ_ζ
+
+Returns mode-space arrays (npsi × mpert) in SFL coordinates. The pointwise product with
+geometry generates harmonics beyond mpert; users needing fuller resolution should increase
+the mode count or use `Analysis.PerturbedEquilibriumModes.modes_to_theta` post-hoc.
+
+The caller passes different inputs for ξ vs b (see `reconstruct_physical_fields`).
+"""
+function _apply_rzphi_transform(
+    geom,
+    ft::Utilities.FourierTransforms.FourierTransform,
+    mtheta::Int,
+    psi_input::Matrix{ComplexF64},
+    theta_input::Matrix{ComplexF64},
+    cova_zeta_input::Matrix{ComplexF64}
+)
+    npsi, mpert = size(psi_input)
+
+    R_modes   = zeros(ComplexF64, npsi, mpert)
+    Z_modes   = zeros(ComplexF64, npsi, mpert)
+    phi_modes = zeros(ComplexF64, npsi, mpert)
+
+    # Per-thread theta-space buffers; the immutable `ft` functor and `geom` are shared read-only.
+    fun_bufs = [(R=zeros(ComplexF64, mtheta), Z=zeros(ComplexF64, mtheta), P=zeros(ComplexF64, mtheta)) for _ in 1:Threads.maxthreadid()]
+
+    Threads.@threads :static for ipsi in 1:npsi
+        buf = fun_bufs[Threads.threadid()]
+        R_fun = buf.R
+        Z_fun = buf.Z
+        phi_fun = buf.P
 
         # Inverse DFT: modes → theta-space
         psi_fun  = Utilities.FourierTransforms.inverse(ft, view(psi_input, ipsi, :))
@@ -919,19 +926,19 @@ function _compute_rzphi_modes(
 
         # Pointwise transformation (Fortran gpeq_rzphi, gpeq.f:484-489)
         for itheta in 1:mtheta
-            J = J_theta[itheta]
+            J = geom.J_theta[itheta, ipsi]
             xwp = psi_fun[itheta]
             xwt = theta_fn[itheta]
             xvz = zeta_fn[itheta]
 
             if abs(J) > 1e-30
-                R_fun[itheta] = (t11[itheta] * xwp + t12[itheta] * xwt) / J
-                Z_fun[itheta] = (t21[itheta] * xwp + t22[itheta] * xwt) / J
+                R_fun[itheta] = (geom.t11[itheta, ipsi] * xwp + geom.t12[itheta, ipsi] * xwt) / J
+                Z_fun[itheta] = (geom.t21[itheta, ipsi] * xwp + geom.t22[itheta, ipsi] * xwt) / J
             else
                 R_fun[itheta] = zero(ComplexF64)
                 Z_fun[itheta] = zero(ComplexF64)
             end
-            phi_fun[itheta] = t33[itheta] * xvz
+            phi_fun[itheta] = geom.t33[itheta, ipsi] * xvz
         end
 
         # Forward DFT: theta-space → modes

--- a/src/PerturbedEquilibrium/FieldReconstruction.jl
+++ b/src/PerturbedEquilibrium/FieldReconstruction.jl
@@ -820,6 +820,18 @@ transformation matrix entries t11/t12/t21/t22/t33 and the Jacobian J_theta, as
 
 These depend only on equilibrium geometry, not on the perturbed field, so they are computed
 once and reused for both the ξ and b reconstructions (Fortran gpeq.f:458-475).
+
+The terms are smooth in ψ, so rather than evaluating the (expensive, 2-D) `rzphi` bicubic at
+every fine u_store ψ (npsi ≈ 1158), the *smooth* rzphi primitives (r², η-offset, J and their
+θ-derivatives) are sampled at the coarse equilibrium ψ-knots (`equil.rzphi_xs`, ≈ mpsi+1) and
+cubic-resampled onto the fine grid — replacing ~6×-redundant 2-D bicubic evaluations with
+cheap 1-D cubic evaluations. θ stays at the DFT resolution.
+
+The ψ-derivatives (dr²/dψ, dη/dψ) are obtained by differentiating the ψ-resample spline, NOT
+by resampling the bicubic's ψ-derivatives directly: the latter are only C¹ in ψ and a cubic
+fit through their knot samples rings badly near the axis/edge. The resampled function values
+reproduce the bicubic exactly on its native knots, so the spline derivative recovers the true
+ψ-derivative to machine precision. The trig / t-matrix assembly is done at the fine grid.
 """
 function _build_rzphi_geometry(
     equil::Equilibrium.PlasmaEquilibrium,
@@ -829,6 +841,39 @@ function _build_rzphi_geometry(
     npsi = length(psi_grid)
     R0 = equil.ro
 
+    knot_psi = collect(equil.rzphi_xs)   # coarse equilibrium ψ-knots
+    nknot = length(knot_psi)
+
+    # Sample the smooth rzphi primitives at the coarse ψ-knots × DFT θ grid, packed into a
+    # single [nknot, 5·mtheta] matrix so one cubic Series interpolant (over ψ) carries every
+    # (primitive, θ) channel. Block o·mtheta .+ (1:mtheta) holds primitive o at all θ.
+    # Channels: r2(0), deta(1), jac(2), dr2_dtheta(3), doff_dtheta(4). The ψ-derivatives of
+    # r2/deta come from differentiating this spline (see below).
+    nch = 5
+    knot_vals = Matrix{Float64}(undef, nknot, nch * mtheta)
+
+    hints = [(Ref(1), Ref(1)) for _ in 1:Threads.maxthreadid()]
+
+    Threads.@threads :static for ik in 1:nknot
+        hint = hints[Threads.threadid()]
+        psi = knot_psi[ik]
+
+        for itheta in 1:mtheta
+            theta = (itheta - 1) / mtheta  # SFL theta ∈ [0, 1)
+            pt = (psi, theta)
+
+            knot_vals[ik, 0*mtheta+itheta] = equil.rzphi_rsquared(pt; hint=hint)
+            knot_vals[ik, 1*mtheta+itheta] = equil.rzphi_offset(pt; hint=hint)
+            knot_vals[ik, 2*mtheta+itheta] = equil.rzphi_jac(pt; hint=hint)
+            knot_vals[ik, 3*mtheta+itheta] = equil.rzphi_rsquared(pt; deriv=DerivOp(0, 1), hint=hint)
+            knot_vals[ik, 4*mtheta+itheta] = equil.rzphi_offset(pt; deriv=DerivOp(0, 1), hint=hint)
+        end
+    end
+
+    # Cubic-in-ψ interpolant of every (primitive, θ) channel; matches the metric-coeff
+    # resampling convention used in `_build_metric_interp`.
+    geom_interp = cubic_interp(knot_psi, Series(knot_vals); bc=CubicFit(), extrap=ExtendExtrap())
+
     t11 = Matrix{Float64}(undef, mtheta, npsi)
     t12 = Matrix{Float64}(undef, mtheta, npsi)
     t21 = Matrix{Float64}(undef, mtheta, npsi)
@@ -836,24 +881,25 @@ function _build_rzphi_geometry(
     t33 = Matrix{Float64}(undef, mtheta, npsi)
     J_theta = Matrix{Float64}(undef, mtheta, npsi)
 
-    hints = [(Ref(1), Ref(1)) for _ in 1:Threads.maxthreadid()]
+    hints1d = [Ref(1) for _ in 1:Threads.maxthreadid()]
 
     Threads.@threads :static for ipsi in 1:npsi
-        hint = hints[Threads.threadid()]
+        h = hints1d[Threads.threadid()]
         psi = psi_grid[ipsi]
+        raw = geom_interp(psi; hint=h)                    # values: r2, deta, jac, dr2_dθ, doff_dθ
+        draw = geom_interp(psi; deriv=DerivOp(1), hint=h) # ψ-derivatives of those channels
 
+        # Assemble the transform matrices at the fine grid (Fortran gpeq.f:458-475). The trig
+        # is evaluated here, not resampled, because deta(ψ) makes c/s oscillate in ψ.
         for itheta in 1:mtheta
-            theta = (itheta - 1) / mtheta  # SFL theta ∈ [0, 1)
-            pt = (psi, theta)
-
-            r2   = equil.rzphi_rsquared(pt; hint=hint)
-            deta = equil.rzphi_offset(pt; hint=hint)
-            jac  = equil.rzphi_jac(pt; hint=hint)
-
-            dr2_dpsi    = equil.rzphi_rsquared(pt; deriv=DerivOp(1, 0), hint=hint)
-            dr2_dtheta  = equil.rzphi_rsquared(pt; deriv=DerivOp(0, 1), hint=hint)
-            doff_dpsi   = equil.rzphi_offset(pt; deriv=DerivOp(1, 0), hint=hint)
-            doff_dtheta = equil.rzphi_offset(pt; deriv=DerivOp(0, 1), hint=hint)
+            theta = (itheta - 1) / mtheta
+            r2 = raw[0*mtheta+itheta]
+            deta = raw[1*mtheta+itheta]
+            jac = raw[2*mtheta+itheta]
+            dr2_dtheta = raw[3*mtheta+itheta]
+            doff_dtheta = raw[4*mtheta+itheta]
+            dr2_dpsi = draw[0*mtheta+itheta]   # d(r2)/dψ
+            doff_dpsi = draw[1*mtheta+itheta]  # d(deta)/dψ
 
             rfac = sqrt(max(0.0, r2))
             eta  = 2π * (theta + deta)


### PR DESCRIPTION
## Summary

Speeds up `FieldReconstruction.jl`'s R/Z/φ reconstruction by eliminating redundant and over-sampled equilibrium-geometry evaluation. **`reconstruct_physical_fields` is ~2× faster (364 → 175 ms warm, DIII-D n=1, `-t 6`) at machine-precision accuracy.**

> **Stacked on #263** (threading). This PR is based on `performance/parallel-field-reconstruction` and shows only the two geometry commits; retarget to `develop` once #263 merges.

## Background

Profiling showed the field-reconstruction bottleneck is **equilibrium bicubic-spline evaluation**, not the mode-space linear algebra. Two issues:

1. `_compute_rzphi_modes` was called twice (ξ and b) and recomputed the **identical** (ψ,θ) transform matrices, which depend only on geometry.
2. The smooth geometry was sampled at every fine u_store ψ (npsi≈1158) when the `rzphi` bicubic only carries ~188 ψ-knots — a ~6× over-sampling.

## Changes

- **De-dup** (`53a88e8`): split into `_build_rzphi_geometry` (built once) + `_apply_rzphi_transform` (per field). Byte-identical.
- **Coarse-grid resample** (`a2e1cd4`): sample the smooth rzphi primitives (r², η-offset, J, θ-derivatives) at the 188 `rzphi_xs` ψ-knots, build a single cubic `Series` interpolant in ψ (same convention as `_build_metric_interp`), and resample onto the fine grid — replacing 2-D bicubic evals with cheap 1-D cubic evals. ψ-derivatives come from **differentiating the resample spline** (resampling the bicubic ψ-derivatives directly rings to ~2600% near axis/edge, as they are only C¹).

## Verification

- **Accuracy**: the R/Z/φ mode outputs (the only fields these functions affect) match a byte-identical baseline to **~1e-15 relative**. NB: the regression harness does *not* track R/Z/φ, so this was validated by direct HDF5 comparison.
- **Regression** `diiid_n1`: **0-diff** on all 30 tracked quantities.
- **Threaded determinism**: full `gpec.h5` (239 numeric datasets) **bit-identical across `-t 1/2/6`**.

## Scope notes

Reconstruction is a small fraction of total runtime (the stability ODE dominates), so the total-run speedup is modest; the win is largest for multi-n runs, scans, and repeated-response loops. I also implemented and benchmarked an area/b_n coarse-grid cache and DFT GEMM batching, but **reverted both** — measured net-negative (Series overhead at mthsurf=256; batching thin DFTs loses the per-ψ `@threads` parallelism, 175→255 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)