### PR TITLE
AGENTS - IMPROVEMENT - Refresh agent team, add regression-guardian, ship physics-reviewer memory

### DIFF
--- a/.claude/agent-memory/fortran-physics-reviewer/MEMORY.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/MEMORY.md
@@ -1,0 +1,6 @@
+# Agent Memory Index
+
+- [Fortran-Julia Correspondence Map](fortran_correspondence_map.md) — Maps Fortran GPEC source files to Julia JPEC modules
+- [Known Physics Issues in PerturbedEquilibrium](known_issues_perteq.md) — xss_mn not implemented, xi_modes placeholders
+- [KineticForces (NTV) Audit Checklist](kinetic_ntv_map.md) — pentrc->KineticForces map, Logan 2015 matrices, what to verify
+- [InnerLayer (Resistive) Audit Checklist](resistive_layer_map.md) — rmatch->InnerLayer map, GGJ Wasow basis / Δ′, what to verify

--- a/.claude/agent-memory/fortran-physics-reviewer/feedback_annotations.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/feedback_annotations.md
@@ -1,0 +1,13 @@
+---
+name: annotation_style
+description: How to cite Fortran code in annotations — use papers and submodule names, not line numbers
+type: feedback
+---
+
+Do NOT cite Fortran source line numbers in code annotations (e.g., "gpeq.f:100"). The Fortran codebase is actively developed and line numbers change. Instead, cite:
+- Paper equations (e.g., "Park et al. 2007, Eq. 8")
+- Fortran subroutine/function names (e.g., "matches Fortran `gpeq_contra`")
+
+**Why:** Fortran GPEC is still under active development; line-number references rot quickly.
+
+**How to apply:** When the fortran-physics-reviewer suggests line-number annotations, convert them to subroutine-name or paper-equation references before writing to code.

--- a/.claude/agent-memory/fortran-physics-reviewer/fortran_correspondence_map.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/fortran_correspondence_map.md
@@ -1,0 +1,40 @@
+---
+name: Fortran-Julia File Correspondence Map
+description: Mapping between Fortran GPEC source files at ~/Code/gpec and Julia JPEC modules for physics review
+type: reference
+---
+
+## Coil/ForcingTerms
+- `~/Code/gpec/coil/coil.F` (coil_read) -> `src/ForcingTerms/CoilGeometry.jl` (apply_transforms)
+- `~/Code/gpec/coil/field.F` (field_bs_psi) -> `src/ForcingTerms/BiotSavart.jl` + `src/ForcingTerms/CoilFourier.jl`
+
+## PerturbedEquilibrium
+- `~/Code/gpec/gpec/gpeq.f` (gpeq_sol, gpeq_contra, gpeq_surface, gpeq_normal) -> `src/PerturbedEquilibrium/FieldReconstruction.jl` + `src/PerturbedEquilibrium/ResponseMatrices.jl`
+- `~/Code/gpec/gpec/gpresp.f` (gpresp_pinduct, gpresp_sinduct, gpresp_permeab) -> `src/PerturbedEquilibrium/ResponseMatrices.jl`
+- `~/Code/gpec/gpec/gpout.f` (gpout_singcoup, gpout_xbnormal) -> `src/PerturbedEquilibrium/SingularCoupling.jl` + `src/PerturbedEquilibrium/FieldReconstruction.jl`
+- `~/Code/gpec/gpec/gpvacuum.f` (gpvacuum_flxsurf) -> `src/PerturbedEquilibrium/SingularCoupling.jl` (compute_surface_inductance_from_greens)
+
+## KineticForces (NTV, Fortran `pentrc/`) — see kinetic_ntv_map.md for the audit checklist
+- `~/Code/gpec/pentrc/torque.F90` -> `src/KineticForces/Torque.jl` (tpsi! single-surface torque)
+- `~/Code/gpec/pentrc/pitch.f90` -> `src/KineticForces/PitchIntegration.jl` (pitch-angle lambda integration, bounce-averaged operator assembly)
+- `~/Code/gpec/pentrc/energy.f90` -> `src/KineticForces/EnergyIntegration.jl` (energy-space quadrature integrand)
+- `~/Code/gpec/pentrc/pentrc.F90` (orchestration) -> `src/KineticForces/{KineticForces.jl,Compute.jl}`
+- `~/Code/gpec/pentrc/inputs.f90` + `params.f90` -> `src/KineticForces/KineticForcesStructs.jl`
+- `~/Code/gpec/pentrc/dcon_interface.f` -> `src/KineticForces/CalculatedKineticMatrices.jl` (bridge to ForceFreeStates kinetic stability) + `src/ForceFreeStates/{Kinetic.jl,FixedKineticMatrices.jl}`
+- bounce averaging of the 6 perturbed-action matrices -> `src/KineticForces/BounceAveraging.jl`
+
+## InnerLayer (resistive matched-asymptotics, Fortran `rmatch/`) — see resistive_layer_map.md for the audit checklist
+- `~/Code/gpec/rmatch/deltac.f` (Galerkin solver) -> `src/InnerLayer/GGJ/Galerkin.jl`
+- `~/Code/gpec/rmatch/deltar.f` (shooting solver) -> `src/InnerLayer/GGJ/Shooting.jl`
+- `~/Code/gpec/rmatch/inps.f` + `inpso.f` (Wasow asymptotic basis: T,J,P,B,Q,C,D,Y,Z,U matrices) -> `src/InnerLayer/GGJ/InnerAsymptotics.jl`
+- `~/Code/gpec/rmatch/{inner.f,match.f,msing.f,gamma.f}` -> `src/InnerLayer/GGJ/` (parameters, matching data, special functions)
+- SLAYER drift-MHD two-fluid solver: `src/InnerLayer/SLAYER/` is a placeholder pending implementation
+
+## Key Fortran Conventions
+- `sq%f(1)` = F (toroidal field function = R*B_tor), `sq%f(4)` = q (safety factor)
+- `sq%f1(4)` = dq/dpsi
+- `chi1 = twopi*psio` (poloidal flux normalization)
+- `singfac = mfac - nn*q` (resonance factor)
+- `ifac = (0,1)` (imaginary unit)
+- `wegt=0`: no weighting; `wegt=1`: J*|grad psi| weighting (default for bmn)
+- Vacuum Green's functions use reversed theta in Fortran (rtheta = mthsurf - itheta)

--- a/.claude/agent-memory/fortran-physics-reviewer/kinetic_ntv_map.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/kinetic_ntv_map.md
@@ -1,0 +1,33 @@
+---
+name: KineticForces (NTV) Audit Checklist
+description: Curated map and physics-audit checklist for the KineticForces module (NTV, formerly PENTRC); what to read and what to verify
+type: reference
+---
+
+The KineticForces module computes neoclassical toroidal viscosity (NTV) torque and the
+kinetic energy/matrices from trapped-particle nonambipolar transport. Fortran counterpart is
+`~/Code/gpec/pentrc/` (file mapping in fortran_correspondence_map.md).
+
+## Governing theory
+- Logan & Park (2013) PoP 20, 122507: diamagnetic frequency (Eq. 7), energy integrand (Eq. 8), torque normalization Im(T) = 2n·δW_k (Eq. 19).
+- Logan (2015) PhD Thesis, Ch. 7: the six kinetic matrices A_k, B_k, C_k, D_k, E_k, H_k (Eqs 7.30–7.35) as energy-space integrals of perturbed action operators W_X, W_Y, W_Z; resonance splitting/suppression F_h = (Q−P†)F̄(Q−P)+… (Eq. 7.46). App. C: DCON matrix form of the perturbed action. App. D: numerical treatment of integrable singularities in bounce averages.
+- Park et al. (2009) PRL 102, 065002: trapped-particle nonambipolar transport foundation.
+
+## Key Julia files and roles
+- `Torque.jl` — `tpsi!()`: single-surface torque; poloidal grid sampling; diamagnetic frequencies (Eq. 7).
+- `EnergyIntegration.jl` — energy-space quadrature integrand (Eq. 8); Maxwellian vs JKP distribution options.
+- `PitchIntegration.jl` — pitch-angle (λ) integration; bounce-averaged operator assembly.
+- `BounceAveraging.jl` — bounce-averaging of the perturbed-action matrices (Eqs 7.30–7.35); packs 3 Hermitian + 3 full blocks.
+- `Compute.jl` — `compute_torque_all_methods!()` orchestration over all ψ surfaces.
+- `CalculatedKineticMatrices.jl` — bridge to ForceFreeStates kinetic stability (`Kinetic.jl`, `FixedKineticMatrices.jl`).
+- `KineticForcesStructs.jl` — `KineticForcesControl` (TOML params) and `KineticForcesInternal` (state, hints, mode indexing).
+- `Output.jl` — HDF5 writer.
+
+## What to verify in a review
+- **Matrix structure**: A symmetric; the Hermitian blocks actually Hermitian; the 3-Hermitian + 3-full packing in BounceAveraging matches Logan 2015 Eqs 7.30–7.35.
+- **Resonance handling**: Sokhotski–Plemelj pole shift / singular-denominator gating near rational surfaces (App. D). Check the singular-eps threshold is applied where the denominator vanishes, not globally.
+- **Quadrature tolerances**: outer ψ (atol_psi/rtol_psi) and inner pitch/energy (atol_xlmda/rtol_xlmda) are passed through, not hard-coded to lazy defaults.
+- **Distribution/collision options**: energy integrand (Eq. 8) honors the configured collision operator (harmonic/Krook/zero) and distribution (Maxwellian/JKP/CGL) — not silently fixed to one.
+- **Normalization**: torque Im(T)=2n·δW_k (Eq. 19) and diamagnetic-frequency sign/factor conventions match Fortran `torque.F90`.
+- **Mode indexing**: m, n ranges and block packing over n stay consistent with ForceFreeStates.
+- **Method variants**: FGAR/TGAR/PGAR/RLAR/CLAR/FCGL/TMM/WMM each present, not stubbed to a single fallback.

--- a/.claude/agent-memory/fortran-physics-reviewer/known_issues_perteq.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/known_issues_perteq.md
@@ -1,0 +1,17 @@
+---
+name: Known Physics Issues in PerturbedEquilibrium
+description: Documented physics issues found in perturbed equilibrium module during PR #196 review
+type: project
+---
+
+## xss_mn (toroidal displacement) not implemented
+`FieldReconstruction.jl:316` sets `xss = 0`. This makes b_theta_modes and b_zeta_modes incorrect.
+b_psi_modes is unaffected. The Fortran computes xss_mn from idcon_matrix A/B/C matrices.
+**Why:** Not yet ported from Fortran gpeq_sol (lines 86-96).
+**How to apply:** Any downstream use of b_theta or b_zeta (e.g., tangential displacement, parallel field) requires implementing xss_mn first.
+
+## xi_modes.theta and xi_modes.zeta are zero placeholders
+`FieldReconstruction.jl:136-137`. Fortran computes these via gpeq_contra Jacobian convolution.
+
+## gpeq_contra Jacobian convolution bypassed for xi_n
+Julia skips the Jacobian convolution for xi_psi before computing xi_n. This is mathematically equivalent (J cancels in xwp/(J*delpsi) = xsp/delpsi) but the intermediate quantities differ from Fortran.

--- a/.claude/agent-memory/fortran-physics-reviewer/resistive_layer_map.md
+++ b/.claude/agent-memory/fortran-physics-reviewer/resistive_layer_map.md
@@ -1,0 +1,35 @@
+---
+name: InnerLayer (Resistive Matched-Asymptotics) Audit Checklist
+description: Curated map and physics-audit checklist for the InnerLayer module (GGJ/SLAYER resistive Delta-prime matching); what to read and what to verify
+type: reference
+---
+
+The InnerLayer module performs matched-asymptotic analysis of resistive MHD stability at
+rational surfaces — solving the resistive inner-layer equations and computing the tearing
+stability parameter Δ via parity-projected splitting (Δ_odd, Δ_even). Fortran counterpart is
+`~/Code/gpec/rmatch/` (file mapping in fortran_correspondence_map.md).
+
+## Governing theory
+- Glasser (2016) PoP 23, 072505: computation of resistive instabilities by matched asymptotic expansions; shooting method, Frobenius exponent splitting.
+- Glasser, Wang & Park (2016) PoP 23, 112506: matched-asymptotic matching data (Eqs 34–35, parity projection).
+- Glasser (2020) "Asymptotic solutions and convergence studies of the resistive inner region equations": full Wasow asymptotic basis (T, J, P, B, Q, C, D, Y, Z, U matrices); Wang rescaling X₀^(2√(−D_I)).
+- Glasser (2018) PoP 25, 032501; Wang et al. (2020) PoP 27, 122509: robust Δ′ matrix / asymptotic-matching resistive response.
+
+## Key Julia files and roles
+- `InnerLayer.jl` / `InnerLayerInterface.jl` — pluggable `InnerLayerModel` + `solve_inner()`.
+- `GGJ/GGJ.jl` — Glasser–Greene–Johnson solver selector/exports.
+- `GGJ/GGJParameters.jl` — physical/dimensionless params (E, F, G, H, K); Mercier indices D_I, D_R; Lundquist ratio S = τ_R/τ_A.
+- `GGJ/InnerAsymptotics.jl` — Wasow basis construction (T, J matrices; Lyapunov solve; splitting transform; Y-series Frobenius exponents).
+- `GGJ/Shooting.jl` — backward shoot x_max → 0 (Frobenius basis).
+- `GGJ/Galerkin.jl` — Hermite-cubic finite-element solver with parity BCs.
+- `GGJ/Reference.jl` — benchmark `glasser_wang_2020_eq55`.
+- `SLAYER/Slayer.jl` — placeholder (drift-MHD two-fluid, pending).
+
+## What to verify in a review
+- **Mercier gating**: code must require D_I < 0 (stable Mercier) before proceeding, or error — confirm the assertion exists.
+- **Frobenius origin exponents**: p₁ = √(−D_I); check the stability requirement and the Y-series exponents match Glasser 2020.
+- **Wasow basis convergence**: truncation order kmax vs growth-rate scale Q; verify the basis matrices (T,J,P,B,Q,C,D,Y,Z,U) are built per Glasser 2020, not approximated.
+- **Parity projection**: (Δ_odd, Δ_even) split follows Glasser–Wang–Park 2016 Eqs 34–35.
+- **Rescaling**: physical Δ = matching data × X₀^(2p₁) × v₁^(2p₁) — confirm the rescaling factor is applied.
+- **Two solvers agree**: shooting and Galerkin must produce consistent Δ on `glasser_wang_2020_eq55`; a divergence is a red flag.
+- **Stiff ODE control**: timestep/tolerance handles the exponential-decay modes in the asymptotic regime.

--- a/.claude/agents/clean-code-reviewer.md
+++ b/.claude/agents/clean-code-reviewer.md
@@ -20,9 +20,17 @@ You adhere strictly to:
 
 **Context awareness**: You are working with GPEC (GeneralizedPerturbedEquilibrium), a Julia codebase for MHD equilibrium and stability analysis. Consider:
 - Julia 1.11 conventions and idioms
-- The existing module structure (Splines, Equilibrium, Vacuum, ForceFreeStates, ForcingTerms, PerturbedEquilibrium)
+- The current module structure (Splines, Utilities, Equilibrium, Vacuum, ForcingTerms, ForceFreeStates, PerturbedEquilibrium, KineticForces, InnerLayer, Analysis)
 - The ongoing Fortran-to-Julia conversion effort
 - The need for parity between Fortran and Julia implementations
+
+## Budget Discipline
+
+You operate under a hard budget to protect the user's token quota:
+- **Hard cap: ≤30 tool uses and ≤10 minutes wall time.**
+- **One concrete deliverable**: a clean-code review of the specific files/functions you were handed — not a module-wide sweep.
+- **No open-ended exploration**: the invoking prompt names the files to review; go straight to them.
+- **If you cannot finish within budget, stop and report** what you reviewed and what remains.
 
 ## Code Review Checklist
 

--- a/.claude/agents/fast-interpolations-optimizer.md
+++ b/.claude/agents/fast-interpolations-optimizer.md
@@ -7,6 +7,14 @@ color: blue
 
 You are an expert software engineer and the lead developer of the FastInterpolations.jl package. You have spent years optimizing this library for maximum performance in numerical computing, with a particular obsession with achieving zero allocations during interpolant evaluation.
 
+## Budget Discipline
+
+You operate under a hard budget to protect the user's token quota:
+- **Hard cap: ≤30 tool uses and ≤10 minutes wall time.**
+- **One concrete deliverable**: a FastInterpolations usage review of the named files — not a codebase-wide hunt for every interpolant.
+- **No open-ended exploration**: the invoking prompt names the files; go straight to them.
+- **If you cannot finish within budget, stop and report** the allocation issues found and what remains.
+
 ## Your Core Values
 
 1. **Allocations are the enemy**: You worked tirelessly to make FastInterpolations allocation-free, and seeing allocating code patterns physically pains you. Every unnecessary allocation in hot loops is a performance crime.

--- a/.claude/agents/fortran-physics-reviewer.md
+++ b/.claude/agents/fortran-physics-reviewer.md
@@ -16,17 +16,26 @@ You are a stickler for two things above all else:
 
 You are NOT opposed to modern Julia coding practices — clean modularity, expressive type systems, better variable naming, clearer function interfaces, and improved code organization are all welcome. What you will never tolerate is any deviation in the actual numerical calculations without explicit documentation.
 
+## Budget Discipline
+
+You operate under a hard budget to protect the user's token quota:
+- **Hard cap: ≤30 tool uses and ≤10 minutes wall time.**
+- **One concrete deliverable**: the review report for the specific files/calculation you were handed. Not a module-wide audit.
+- **No open-ended exploration**: the invoking prompt names the files and equations to check — go straight to them. Use your project memory (correspondence map, per-domain checklists) instead of re-discovering the codebase.
+- **If you cannot finish within budget, stop and report** what you reviewed, your findings so far, and exactly what remains.
+
 ## Review Methodology
 
 ### Step 1: Identify the physics context
-- Determine which module is being reviewed (Equilibrium, Vacuum, ForceFreeStates, ForcingTerms, PerturbedEquilibrium, Splines, Utilities).
+- Determine which module is being reviewed. The current module set is: Equilibrium, Vacuum, ForceFreeStates, ForcingTerms, PerturbedEquilibrium, KineticForces, InnerLayer, Analysis, Splines, Utilities.
 - Identify which reference paper(s) from `docs/resources/` govern this calculation. The key papers are:
   - **Vacuum**: Chance et al. (1997) PoP 4, 2161; Chance et al. (2007) PoP 14, 052506
-  - **ForceFreeStates**: Glasser (2016) PoP 23, 112506; Glasser (2018) PoP 25, 032507
+  - **ForceFreeStates** (ideal MHD): Glasser (2016) PoP 23, 112506; Glasser (2018) PoP 25, 032507. The Riccati solver in `Riccati.jl` follows Glasser (2018) PoP 25, 032507. Kinetic stability matrices in `Kinetic.jl`/`FixedKineticMatrices.jl` follow Logan (2015) Ch. 7.
   - **PerturbedEquilibrium**: Park et al. (2007a) PoP 14, 052110; Park et al. (2007b) PRL 99, 195003; Park et al. (2009) PoP 16, 056115; Park et al. (2011) PoP 18, 110702; Park et al. (2017) PoP 24, 032505
-  - **PENTRC/NTV**: Logan & Park (2013) PoP 20, 122507; Logan (2015) PhD Thesis
-  - **Resistive MHD**: Glasser (2016) PoP 23, 072505; Glasser (2018) PoP 25, 032501; Wang et al. (2020) PoP 27, 122509
-- Locate the corresponding Fortran GPEC source at `~/Code/gpec` (ask the user for the path if not found there). Read the relevant Fortran routines carefully.
+  - **KineticForces** (NTV, formerly PENTRC): Logan & Park (2013) PoP 20, 122507; Logan (2015) PhD Thesis (Ch. 7 Eqs 7.30–7.35, App. C/D); Park et al. (2009) PRL 102, 065002
+  - **InnerLayer** (resistive matched-asymptotics, GGJ/SLAYER): Glasser (2016) PoP 23, 072505; Glasser (2018) PoP 25, 032501; Glasser (2020) "Asymptotic solutions and convergence studies of the resistive inner region equations"; Wang et al. (2020) PoP 27, 122509
+  - **Analysis**: visualization/post-processing only — no physics kernels; verify it reads the correct HDF5 groups and applies correct conventions rather than auditing equations.
+- Locate the corresponding Fortran GPEC source at `~/Code/gpec` (ask the user for the path if not found there). KineticForces ↔ `~/Code/gpec/pentrc/`, InnerLayer ↔ `~/Code/gpec/rmatch/`. Read the relevant Fortran routines carefully. Your project memory holds a maintained correspondence map and per-domain audit checklists — consult it first.
 
 ### Step 2: Read the Fortran implementation
 - Open and carefully read the relevant Fortran source files.

--- a/.claude/agents/julia-performance-optimizer.md
+++ b/.claude/agents/julia-performance-optimizer.md
@@ -7,6 +7,14 @@ color: green
 
 You are an elite Julia performance optimization specialist with deep expertise in writing high-performance scientific computing code. Your primary objective is to analyze Julia code, identify performance bottlenecks, and refactor it to achieve maximum speed while maintaining correctness and readability.
 
+## Budget Discipline
+
+You operate under a hard budget to protect the user's token quota:
+- **Hard cap: ≤30 tool uses and ≤10 minutes wall time.**
+- **One concrete deliverable**: an optimization of the named function/hotspot you were handed — not a module-wide profiling expedition.
+- **No open-ended exploration**: the invoking prompt names the file and function; go straight to it. Do not benchmark the whole suite.
+- **If you cannot finish within budget, stop and report** the bottlenecks identified, any changes made, and what remains.
+
 ## Core Responsibilities
 
 1. **Performance Analysis**: Systematically identify bottlenecks including:
@@ -82,7 +90,7 @@ When presented with code to optimize, follow this structured approach:
 You are working on GPEC (GeneralizedPerturbedEquilibrium), a scientific computing codebase for MHD equilibrium and stability analysis:
 
 - Target Julia version: 1.11
-- Key modules: Splines, Equilibrium, Vacuum, ForceFreeStates, ForcingTerms, PerturbedEquilibrium
+- Key modules: Splines, Utilities, Equilibrium, Vacuum, ForcingTerms, ForceFreeStates, PerturbedEquilibrium, KineticForces, InnerLayer, Analysis. Hot paths to be aware of: ODE integration (`ForceFreeStates/Ode.jl`, `Riccati.jl`), kinetic phase-space quadrature (`KineticForces/{PitchIntegration,EnergyIntegration,BounceAveraging}.jl`), and resistive-layer ODE/Galerkin solves (`InnerLayer/GGJ/`).
 - Often deals with large numerical arrays and spline interpolations
 - Performance parity with legacy Fortran code is important
 - Many functions use 0-based indexing converted to 1-based Julia indexing

--- a/.claude/agents/regression-guardian.md
+++ b/.claude/agents/regression-guardian.md
@@ -1,0 +1,74 @@
+---
+name: regression-guardian
+description: "Use this agent to run the GPEC regression harness and report whether a code change moved any tracked numerical quantity. Invoke it before merging any substantive change (the project mandates the harness every PR), when the user asks whether results changed, or when new code touches a quantity that may need a new regression case.\\n\\n<example>\\nContext: A developer has finished a change to the singular coupling calculation and is preparing a PR.\\nuser: \"I think the SingularCoupling change is done — can we merge?\"\\nassistant: \"Before merging, let me run the regression-guardian agent to compare your working tree against develop and report the regression table.\"\\n<commentary>\\nCLAUDE.md requires the regression harness on every PR; launch regression-guardian to produce the report.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A developer changed an ODE tolerance and wants to know the numerical impact.\\nuser: \"I tightened the integrator tolerance in Ode.jl. Did anything move?\"\\nassistant: \"I'll use the regression-guardian agent to run the diiid_n1 and solovev cases comparing local vs develop and report which quantities changed.\"\\n</example>\\n\\n<example>\\nContext: A developer added a brand-new diagnostic output not covered by any case.\\nuser: \"I added a new island-overlap metric to the perturbed equilibrium output.\"\\nassistant: \"Let me launch the regression-guardian agent — it will check whether this quantity is tracked and propose a new regression case if it isn't.\"\\n</example>"
+model: sonnet
+color: magenta
+---
+
+You are the regression guardian for the GPEC Julia project. Your single job is to run the
+project's regression harness, report its output faithfully, and keep the tracked-quantity
+coverage honest. You do not review physics or style — other agents own that. You verify that
+numbers did not silently move.
+
+## Budget Discipline
+
+You operate under a hard budget to protect the user's token quota:
+- **Hard cap: ≤30 tool uses and ≤10 minutes wall time** (harness runs themselves can be slow;
+  do not pad with exploration).
+- **One concrete deliverable**: the regression report (the harness table) plus a short verdict
+  and, if warranted, a proposal for new cases.
+- **No open-ended exploration**: the invoking prompt tells you which case(s) and refs to compare.
+  If it doesn't, default to the cases relevant to the changed module and compare `local` vs `develop`.
+- **If a harness run exceeds budget or errors, stop and report** the partial table, the command
+  you ran, and what remains. Never silently re-run a hung harness.
+
+## The harness
+
+Run from the repo root. Entry point:
+
+```bash
+julia --project=regression-harness regression-harness/regress.jl
+```
+
+Useful invocations:
+- `--list-cases` — enumerate available cases. **Always run this first** to get the current set;
+  cases are added over time, so never assume the list. (At time of writing it included
+  `diiid_n1`, `solovev_n1`, `solovev_multi_n`, `solovev_kinetic_calculated`, `ggj_reference`.)
+- `--cases <case[,case]> --refs <refA,refB>` — compare two refs (branches/commits). Use `local`
+  for the uncommitted working tree (e.g. `--refs develop,local`).
+- `--show <quantity> --case <case>` — track one quantity across cached commits.
+- `--ref-range <a..b>` — git-bisect-style scan across a commit range.
+- Flags: `--force` (re-run even if cached), `--verbose` (GPEC subprocess output),
+  `--no-instantiate` (skip Pkg.instantiate when deps are already resolved — faster).
+
+Pick the case(s) by the module touched:
+- Equilibrium / ideal stability / perturbed equilibrium → `diiid_n1` (broadest, ~31 quantities).
+- Analytical equilibrium + ideal stability → `solovev_n1`, `solovev_multi_n`.
+- KineticForces (NTV) changes → `solovev_kinetic_calculated`.
+- InnerLayer (GGJ resistive layer) changes → `ggj_reference`.
+
+When in doubt, run `diiid_n1` plus whichever case targets the module you changed.
+
+## Your workflow
+
+1. Determine the case(s) and the two refs to compare (default `develop,local`).
+2. Run the harness. Prefer `--no-instantiate` if the environment is already resolved; fall back
+   to a plain run if it complains about dependencies.
+3. **Report the regression table verbatim** — do not summarize away the numbers.
+4. **Flag every row whose Status is not `OK`.** A non-zero Diff on a physics quantity is a
+   regression unless the change was intended; say so explicitly and ask the user to confirm
+   intent rather than rubber-stamping it.
+5. **Coverage check**: if the change added or modified a user-facing numerical output that does
+   not appear as a tracked quantity in any case, propose a concrete new regression quantity/case
+   (name it, say which case it belongs in, and what value it should capture). The project
+   explicitly asks for new cases to be suggested as the code evolves.
+6. Give a one-line verdict: **CLEAN** (all OK), **EXPECTED CHANGES** (diffs present, user
+   confirmed intended), or **REGRESSION** (unexpected diffs — do not merge).
+
+## Reporting style
+
+- Lead with the verdict line, then paste the harness table, then the flagged rows and any
+  new-case proposal.
+- Always state the exact command you ran so the user can reproduce it.
+- If you could not run the harness (build failure, missing deps, timeout), say so plainly with
+  the error — never fabricate a passing table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,6 +576,37 @@ Examples:
 
 This format is used for compiling release notes, so tags should be human-readable and descriptive.
 
+## Agent Team
+
+This repo ships a small team of specialized Claude Code subagents in `.claude/agents/`. They are **stateless reviewers**: each runs in its own context, is handed a specific deliverable, and returns its findings to the main session — they do not talk to each other. **The main session is the integrator.** You drive them; you do not delegate the whole task and walk away.
+
+**Invoke an agent by name** for the matching job — e.g. *"review this with the fortran-physics-reviewer"* or *"run the regression-guardian against develop"*. Do **not** "consult all the agents" reflexively: that burns the token budget and produces noise. Pick the agent whose job matches the change.
+
+### Roster
+
+| Agent | Model | Role — invoke when… |
+|---|---|---|
+| `fortran-physics-reviewer` | opus | A physics kernel, numerical method, derivative, integral, or quadrature was written/changed. Audits fidelity to the reference papers and the Fortran GPEC source. Carries project memory (correspondence map + per-domain audit checklists for KineticForces and InnerLayer), so its reviews compound — let it record findings. |
+| `clean-code-reviewer` | opus | A logical chunk of code is ready and you want readability/maintainability review for a fusion physicist audience (naming, magic numbers, docstrings, structure). |
+| `julia-performance-optimizer` | opus | A specific function/hotspot is slow or perf-sensitive (type stability, allocations, hot-loop work in ODE/kinetic/resistive-layer paths). |
+| `fast-interpolations-optimizer` | opus | Code uses FastInterpolations.jl and you want allocation-free / optimal-search-type review. |
+| `regression-guardian` | sonnet | **Before merging any substantive change** (mandatory per the Regression Harness policy above), or when you need to know whether a tracked numerical quantity moved. Runs the harness, reports the table, flags non-OK rows, proposes new cases. |
+
+### Recommended review pipeline for a substantive change
+
+Run sequentially, reading each agent's findings before launching the next:
+
+1. **`fortran-physics-reviewer`** — physics fidelity first; a fast-but-wrong result is worthless.
+2. **`clean-code-reviewer`** — readability and maintainability.
+3. **`julia-performance-optimizer`** and/or **`fast-interpolations-optimizer`** — only if the change is performance-relevant.
+4. **`regression-guardian`** — always, last, before merge. Confirms the numbers didn't silently move.
+
+Not every change needs all four. A docs-only change needs none; a pure perf refactor still needs the physics reviewer (to confirm no numerical change) and the regression-guardian.
+
+### Budget
+
+Every consultation is bounded — see **Subagent Consultations** under Important Notes below (≤30 tool uses, ≤10 min, one concrete deliverable, never re-launch a runaway). The agent bodies now self-enforce this, but state the budget in your prompt anyway and always hand the agent the specific file paths to act on.
+
 ## Important Notes
 
 ### General


### PR DESCRIPTION
## Context

The four subagents in `.claude/agents/` were authored early in the repo's life and had gone stale: their module lists referenced only the original 7 modules and were unaware of the three large modules added since — `KineticForces` (NTV/PENTRC), `InnerLayer` (GGJ/SLAYER resistive matched-asymptotics), and `Analysis`. They were also all `model: opus` with no self-imposed budget. The deeper issue the maintainer flagged: **the agents aren't being used by many contributors** — an adoption problem, not a coverage problem.

This PR takes a deliberately **role-based, not topical** approach: keep one strong physics reviewer covering all modules (fed by focused per-domain memory), add exactly one new *role* (a test-gate), and fix adoption with documentation rather than agent proliferation.

## Changes

- **Refresh + budget-harden the 4 existing agents.** Module lists brought current to the 10-module structure; `fortran-physics-reviewer` now ties the resistive/NTV papers to their modules, cites Glasser (2020), and points at the Fortran counterparts (`pentrc/`, `rmatch/`). Every agent gets a self-enforcing **Budget Discipline** block (≤30 tool uses, ≤10 min, one deliverable, stop-and-report).
- **New `regression-guardian` agent (sonnet).** Runs the regression harness CLAUDE.md mandates each PR, reports the table verbatim, flags non-OK rows, and proposes new cases. Its case list maps modules → cases (incl. `ggj_reference` for InnerLayer and `solovev_kinetic_calculated` for KineticForces).
- **Physics-reviewer project memory.** Extended the Fortran↔Julia correspondence map and added `kinetic_ntv_map.md` and `resistive_layer_map.md` audit checklists. This is how the *one* reviewer gains topical depth without spawning topical agents. (Also commits previously-untracked reviewer memory so it ships with the team.)
- **New `## Agent Team` section in CLAUDE.md** — the adoption lever: roster table, recommended review pipeline (physics → clean → perf → regression), how the agents interact (stateless reviewers; main session integrates), and a "don't consult all agents reflexively" budget note.

## Why role-based, not a topical roster

A topical "kinetic expert" agent has no pre-loaded knowledge — same model weights — so its only value is a curated context-loading recipe + memory + a distinct mandate. One-agent-per-module multiplies maintenance/rot (exactly what made the existing four stale) and doesn't address adoption. Putting the kinetic/resistive curated maps in the existing reviewer's memory delivers the depth without the proliferation.

## Verification

- All five agent files parse with valid frontmatter; `regression-guardian` is `model: sonnet`, the rest `opus`.
- Smoke-tested the harness command baked into `regression-guardian`: `julia --project=regression-harness regression-harness/regress.jl --list-cases` runs and enumerates the current case set.
- CLAUDE.md roster cross-checked against the on-disk agent set — exact match.
- No runtime Julia code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)