### PR TITLE
CI - IMPROVEMENT - Auto-merge with a merge commit to preserve commit history

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -17,10 +17,10 @@ jobs:
     if: github.event.action == 'labeled' && github.event.label.name == 'auto-merge'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge (squash)
+      - name: Enable auto-merge (merge commit)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+        run: gh pr merge --auto --merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
 
   disable-auto-merge:
     name: Disable auto-merge


### PR DESCRIPTION
## Summary

Switch the `auto-merge` label workflow from `--squash` to `--merge` so labeled PRs land as a true merge commit, preserving the full branch commit history on `develop`/`main` instead of collapsing it into one squashed commit.

The repo already allows merge commits (`allow_merge_commit: true`), so no repo-settings change is needed.

## Change

`.github/workflows/auto-merge.yaml` — one line:
```diff
-        run: gh pr merge --auto --squash ...
+        run: gh pr merge --auto --merge ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
