### PR TITLE
KineticForces - PERFORMANCE - Concretely type geometric-matrix interpolants (#247)

### DIFF
--- a/src/KineticForces/BounceAveraging.jl
+++ b/src/KineticForces/BounceAveraging.jl
@@ -519,7 +519,7 @@ function _bounce_integrate(
         # Fourier modes at this θ (Fortran lines 702-708) — write into pre-allocated
         # expm buffer using the ORIGINAL expression order to preserve bit-level parity.
         @inbounds for mi in 1:mpert
-            expm[mi] = exp(im * twopi * mfac[mi] * θ)
+            expm[mi] = cis(twopi * mfac[mi] * θ)
         end
         # Replaces `sum(dbob_m_f .* expm)` / `sum(divx_m_f .* expm) * divxfac`
         # with direct accumulators; same evaluation order as the broadcast + sum.
@@ -532,7 +532,7 @@ function _bounce_integrate(
         divx *= divxfac
 
         # Action integrand (Fortran line 706-708)
-        phase = exp(-twopi * im * n * q * (θ - theta0))
+        phase = cis(-twopi * n * q * (θ - theta0))
         jvtheta[i] = dt * jac * B_val *
             (divx * sqrt_vpar + dbob * (1.0 - 1.5 * lmda * B_val / bo) / sqrt_vpar) *
             phase
@@ -581,7 +581,7 @@ function _bounce_integrate(
     if do_matrices
         pl = Vector{ComplexF64}(undef, ntheta)
         @inbounds for i in 1:ntheta
-            pl[i] = exp(-twopi * im * lnq * cum_wb_arr[i] * nrm / pl_denom)
+            pl[i] = cis(-twopi * lnq * cum_wb_arr[i] * nrm / pl_denom)
         end
         @inbounds for i in 1:ntheta
             w = (i == 1 || i == ntheta) ? 0.5 : 1.0
@@ -590,7 +590,7 @@ function _bounce_integrate(
     else
         pl = nothing
         @inbounds for i in 1:ntheta
-            pli = exp(-twopi * im * lnq * cum_wb_arr[i] * nrm / pl_denom)
+            pli = cis(-twopi * lnq * cum_wb_arr[i] * nrm / pl_denom)
             w = (i == 1 || i == ntheta) ? 0.5 : 1.0
             bj_integral += w * conj(jvtheta[i]) * (pli + one_minus_sigma / (pli + SINGULAR_EPS))
         end

--- a/src/KineticForces/KineticForcesStructs.jl
+++ b/src/KineticForces/KineticForcesStructs.jl
@@ -100,6 +100,15 @@ end
 # ============================================================================
 # Internal State/Working Variables
 # ============================================================================
+
+# Concrete type of the geometric-matrix interpolants built by
+# `ForceFreeStates.build_kinetic_metric_matrices`, derived from a representative
+# `cubic_interp` call so the 7-parameter `CubicSeriesInterpolant{...}` need not be
+# spelled out. Used to concretely type the smats..zmats fields below so the per-ψ
+# `intr.smats(psi)` reads in `Torque.jl` are statically dispatched, not boxed
+# `Any` calls (issue #247).
+const GeomInterp = typeof(cubic_interp(collect(0.0:0.25:1.0), Series(zeros(ComplexF64, 5, 1)); extrap=ExtendExtrap()))
+
 """
     KineticForcesInternal
 
@@ -164,11 +173,11 @@ this struct.
 
     # Raw geometric matrices for kinetic W vector construction
     # (Fortran dcon_interface.f fmodb s/t/x/y/z — NOT the DCON a/b/c/d/e/h matrices)
-    smats::Any = nothing           # CubicSeriesInterpolant, mpert² series over ψ
-    tmats::Any = nothing
-    xmats::Any = nothing
-    ymats::Any = nothing
-    zmats::Any = nothing
+    smats::Union{Nothing,GeomInterp} = nothing   # CubicSeriesInterpolant, mpert² series over ψ
+    tmats::Union{Nothing,GeomInterp} = nothing
+    xmats::Union{Nothing,GeomInterp} = nothing
+    ymats::Union{Nothing,GeomInterp} = nothing
+    zmats::Union{Nothing,GeomInterp} = nothing
 
     # Clebsch displacement vectors for mode-coupled dW contraction
     xs_m::Any = nothing            # Vector of 3 CubicSeriesInterpolants: [ξ_ψ, ξ_+, ξ_-]


### PR DESCRIPTION
## Summary

Closes the investigation in #247. Ships a **minimal type-stability fix** for the kinetic geometric-matrix interpolants, plus a bit-identical `cis` cleanup. Two files, +18/−9.

- **Concrete typing (`KineticForcesStructs.jl`):** the five `smats/tmats/xmats/ymats/zmats` fields were `::Any`, making each per-ψ `intr.smats(psi)` read in `Torque.jl` a dynamic dispatch with a boxed return. They are now `Union{Nothing,GeomInterp}` where `GeomInterp` is the concrete `CubicSeriesInterpolant` type (derived via `typeof` from a representative `cubic_interp` call, so the 7-parameter type isn't hard-coded). The existing `!isnothing(...)` guards narrow the union → static dispatch. No call-site changes; the five named matrices are preserved.
- **`cis` cleanup (`BounceAveraging.jl`):** four `exp(im*x)` → `cis(x)` in the bounce hot loop (value-identical for real `x`).

## On #247's proposal (fuse the 5 interpolants into one) — tried, dropped

#247 proposed packing the five interpolants into a single `5·mpert²`-column `CubicSeriesInterpolant` so one bracket search serves all five. That was implemented and benchmarked against this minimal type fix and `develop` on the **realistic DIII-D KEFIT kinetic case** (`kinetic_source="calculated"`, mpert=34, force_termination; warm runs, 8 threads):

| Variant | min runtime | alloc |
|---|---|---|
| develop | 210–216 s | 658 GB |
| type fix only (this PR, no cis) | 208 s | 658 GB |
| type fix + cis (this PR) | 187 s | 658 GB |
| **type fix + hcat fusion** | 209 s | 658 GB |

All variants land in the laptop's ±~15% session-noise band with **identical 658 GB allocations and ~40–47% GC**. The run is GC/ODE-bound; the geometric-matrix reads are a negligible fraction, so **the fusion gives no measurable end-to-end benefit** — and it costs code clarity (one opaque packed block vs five named matrices). It is therefore **not included**. The type fix is kept as a legitimate type-stability/code-quality improvement (confirmed: the field type is now concrete, not `Any`), even though it is perf-neutral on the realistic case.

## Validation

Regression harness (`solovev_kinetic_calculated`, `diiid_n1`) vs `develop`: **all OK** (15 + 30 quantities unchanged). The concrete typing is behavior-neutral and `cis` is value-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)