### PR TITLE
KineticForces: single METHOD_REGISTRY for NTV method flags, docs, and dispatch

### DIFF
--- a/src/KineticForces/Compute.jl
+++ b/src/KineticForces/Compute.jl
@@ -158,27 +158,16 @@ function compute_torque_all_methods!(state::KineticForcesState, intr::KineticFor
                                      ctrl::KineticForcesControl, equil,
                                      kinetic_profiles::Equilibrium.KineticProfileSplines)
 
-    flags = [
-        ctrl.fgar_flag, ctrl.tgar_flag, ctrl.pgar_flag,
-        ctrl.rlar_flag, ctrl.clar_flag, ctrl.fcgl_flag,
-        ctrl.fwmm_flag, ctrl.twmm_flag, ctrl.pwmm_flag,
-        ctrl.ftmm_flag, ctrl.ttmm_flag, ctrl.ptmm_flag,
-        ctrl.fkmm_flag, ctrl.tkmm_flag, ctrl.pkmm_flag,
-        ctrl.frmm_flag, ctrl.trmm_flag, ctrl.prmm_flag
-    ]
+    for entry in METHOD_REGISTRY
+        getfield(ctrl, entry.flag) || continue
 
-    for m in 1:length(intr.methods)
-        if !flags[m]
-            continue
-        end
-
-        method = intr.methods[m]
+        method = entry.name
         intr.method = method
         is_matrix_method = occursin("mm", method)
 
         if ctrl.verbose
             println("---------------------------------------------")
-            println("$method - $(intr.docs[m])")
+            println("$method - $(entry.doc)")
         end
 
         # Allocate full block-diagonal matrix if needed

--- a/src/KineticForces/KineticForcesStructs.jl
+++ b/src/KineticForces/KineticForcesStructs.jl
@@ -11,8 +11,8 @@ Single source of truth for the NTV calculation methods. Each entry is a NamedTup
 - `doc`   — one-line description printed in verbose output
 
 The method names/docs and the `Compute.jl` enable list are all derived from this
-tuple, and `Torque.jl` routes on `kind`, so the 18 methods are enumerated in exactly
-one place. To add a method: append an entry here and add the matching `*_flag` field
+tuple, and `Torque.jl` routes on `kind`, so the methods are enumerated in one place. 
+To add a method: append an entry here and add the matching `*_flag` field
 to `KineticForcesControl`.
 """
 const METHOD_REGISTRY = (

--- a/src/KineticForces/KineticForcesStructs.jl
+++ b/src/KineticForces/KineticForcesStructs.jl
@@ -1,4 +1,55 @@
 """
+    METHOD_REGISTRY
+
+Single source of truth for the NTV calculation methods. Each entry is a NamedTuple
+`(name, flag, kind, doc)`:
+- `name`  — short method identifier used as the HDF5 group key and in `intr.method`
+- `flag`  — the `KineticForcesControl` field symbol that enables the method
+- `kind`  — dispatch routing tag consumed by `method_kind` / `Torque.jl`
+            (`:gar` for the GAR/matrix family, `:fcgl`/`:rlar`/`:clar` for the
+            three special-cased methods)
+- `doc`   — one-line description printed in verbose output
+
+The method names/docs and the `Compute.jl` enable list are all derived from this
+tuple, and `Torque.jl` routes on `kind`, so the 18 methods are enumerated in exactly
+one place. To add a method: append an entry here and add the matching `*_flag` field
+to `KineticForcesControl`.
+"""
+const METHOD_REGISTRY = (
+    (name="fgar", flag=:fgar_flag, kind=:gar, doc="Full general-aspect-ratio calculation"),
+    (name="tgar", flag=:tgar_flag, kind=:gar, doc="Trapped particle general-aspect-ratio calculation"),
+    (name="pgar", flag=:pgar_flag, kind=:gar, doc="Passing particle general-aspect-ratio calculation"),
+    (name="rlar", flag=:rlar_flag, kind=:rlar, doc="Trapped particle large-aspect-ratio calculation"),
+    (name="clar", flag=:clar_flag, kind=:clar, doc="Trapped particle cylindrical large-aspect-ratio calculation"),
+    (name="fcgl", flag=:fcgl_flag, kind=:fcgl, doc="Fluid Chew–Goldberger–Low calculation"),
+    (name="fwmm", flag=:fwmm_flag, kind=:gar, doc="Full energy calculation using MXM Euler–Lagrange matrix"),
+    (name="twmm", flag=:twmm_flag, kind=:gar, doc="Trapped energy calculation using MXM Euler–Lagrange matrix"),
+    (name="pwmm", flag=:pwmm_flag, kind=:gar, doc="Passing energy calculation using MXM Euler–Lagrange matrix"),
+    (name="ftmm", flag=:ftmm_flag, kind=:gar, doc="Full torque calculation using MXM Euler–Lagrange matrix"),
+    (name="ttmm", flag=:ttmm_flag, kind=:gar, doc="Trapped torque calculation using MXM Euler–Lagrange matrix"),
+    (name="ptmm", flag=:ptmm_flag, kind=:gar, doc="Passing torque calculation using MXM Euler–Lagrange matrix"),
+    (name="fkmm", flag=:fkmm_flag, kind=:gar, doc="Full MXM Euler–Lagrange energy matrix norm calculation"),
+    (name="tkmm", flag=:tkmm_flag, kind=:gar, doc="Trapped MXM Euler–Lagrange energy matrix norm calculation"),
+    (name="pkmm", flag=:pkmm_flag, kind=:gar, doc="Passing MXM Euler–Lagrange energy matrix norm calculation"),
+    (name="frmm", flag=:frmm_flag, kind=:gar, doc="Full MXM Euler–Lagrange torque matrix norm calculation"),
+    (name="trmm", flag=:trmm_flag, kind=:gar, doc="Trapped MXM Euler–Lagrange torque matrix norm calculation"),
+    (name="prmm", flag=:prmm_flag, kind=:gar, doc="Passing MXM Euler–Lagrange torque matrix norm calculation"))
+
+"""
+    method_kind(name) -> Symbol
+
+Return the dispatch routing tag (`:gar`, `:fcgl`, `:rlar`, `:clar`) for the NTV
+method `name`, looked up from [`METHOD_REGISTRY`]. Errors on an unknown method.
+"""
+function method_kind(name::AbstractString)
+    for entry in METHOD_REGISTRY
+        entry.name == name && return entry.kind
+    end
+    error("ERROR: torque - unknown method: $name")
+end
+
+
+"""
     KineticForcesControl
 
 User-facing control parameters from the TOML `[KineticForces]` section.
@@ -178,32 +229,9 @@ this struct.
     tsurf::ComplexF64 = 0.0 + 0.0im   # Surface torque/energy
     teq::ComplexF64 = 0.0 + 0.0im     # Equilibrium grid result
 
-    # Method tracking
+    # Method tracking — available methods/docs come from `METHOD_REGISTRY`.
     method::String = ""
     wtw::Array{ComplexF64,3} = Array{ComplexF64}(undef, 0, 0, 0)
-    methods::Vector{String} = [
-        "fgar", "tgar", "pgar", "rlar", "clar", "fcgl",
-        "fwmm", "twmm", "pwmm", "ftmm", "ttmm", "ptmm",
-        "fkmm", "tkmm", "pkmm", "frmm", "trmm", "prmm"]
-    docs::Vector{String} = [
-        "Full general-aspect-ratio calculation",
-        "Trapped particle general-aspect-ratio calculation",
-        "Passing particle general-aspect-ratio calculation",
-        "Trapped particle large-aspect-ratio calculation",
-        "Trapped particle cylindrical large-aspect-ratio calculation",
-        "Fluid Chew–Goldberger–Low calculation",
-        "Full energy calculation using MXM Euler–Lagrange matrix",
-        "Trapped energy calculation using MXM Euler–Lagrange matrix",
-        "Passing energy calculation using MXM Euler–Lagrange matrix",
-        "Full torque calculation using MXM Euler–Lagrange matrix",
-        "Trapped torque calculation using MXM Euler–Lagrange matrix",
-        "Passing torque calculation using MXM Euler–Lagrange matrix",
-        "Full MXM Euler–Lagrange energy matrix norm calculation",
-        "Trapped MXM Euler–Lagrange energy matrix norm calculation",
-        "Passing MXM Euler–Lagrange energy matrix norm calculation",
-        "Full MXM Euler–Lagrange torque matrix norm calculation",
-        "Trapped MXM Euler–Lagrange torque matrix norm calculation",
-        "Passing MXM Euler–Lagrange torque matrix norm calculation"]
 
     verbose::Bool = false
 end

--- a/src/KineticForces/Torque.jl
+++ b/src/KineticForces/Torque.jl
@@ -205,24 +205,23 @@ function tpsi!(tpsi_var::Ref{ComplexF64}, psi::Float64, n::Int, l::Int,
         println("  method = ", method)
     end
 
-    # Method selection
-    if method == "fcgl"
+    # Method selection — route on the registry dispatch tag (errors on unknown method)
+    kind = method_kind(method)
+    if kind == :fcgl
         tpsi_var[] = calculate_fcgl(psi, n, l, tspl, dbob_m_f, divx_m_f, divxfac,
                                     n_s, T_s, equil, intr)
 
-    elseif method == "rlar"
+    elseif kind == :rlar
         tpsi_var[] = calculate_rlar(psi, n, l, q, epsr, wdian, wdiat, welec,
                                     wdhat, wbhat, nueff, dVdpsi, n_s, T_s,
                                     dbob_m_f, intr.bo, bmin)
 
-    elseif method == "clar"
+    elseif kind == :clar
         tpsi_var[] = calculate_clar(psi, n, l, q, epsr, wdian, wdiat, welec,
                                     nuk, intr.bo, bmax, bmin, n_s, T_s, mass, chrg,
                                     tspl, dbob_m_f, divx_m_f, divxfac, wdfac)
 
-    elseif method in ["fgar", "tgar", "pgar", "fwmm", "twmm", "pwmm",
-                      "ftmm", "ttmm", "ptmm", "fkmm", "tkmm", "pkmm",
-                      "frmm", "trmm", "prmm"]
+    else  # :gar — fgar/tgar/pgar + all *mm matrix methods
         # Evaluate geometric matrices at current ψ if matrix path
         smat_f = nothing
         tmat_f = nothing
@@ -247,8 +246,6 @@ function tpsi!(tpsi_var::Ref{ComplexF64}, psi::Float64, n::Int, l::Int,
                                    energy_atol=atol_xlmda, energy_rtol=rtol_xlmda,
                                    pitch_atol=atol_xlmda, pitch_rtol=rtol_xlmda,
                                    rex_override=rex_override, imx_override=imx_override)
-    else
-        error("ERROR: torque - unknown method")
     end
 
     if intr.verbose

--- a/test/runtests_kinetic.jl
+++ b/test/runtests_kinetic.jl
@@ -283,9 +283,20 @@
         @test intr.ro == 0.0
         @test intr.bo == 0.0
         @test intr.mpert == 0
-        @test length(intr.methods) == 18
-        @test length(intr.docs) == 18
         @test intr.chi1 == 0.0
+    end
+
+    @testset "METHOD_REGISTRY" begin
+        # The registry is the single source of truth for NTV methods. Every entry's
+        # flag must be a real KineticForcesControl field (the TOML kwargs splat relies
+        # on it) and carry a recognized dispatch kind. No fixed count is asserted —
+        # adding a method should not require editing a magic number here.
+        for entry in KF.METHOD_REGISTRY
+            @test entry.flag in fieldnames(KF.KineticForcesControl)
+            @test endswith(string(entry.flag), "_flag")
+            @test entry.kind in (:gar, :fcgl, :rlar, :clar)
+            @test KF.method_kind(entry.name) == entry.kind
+        end
     end
 
     @testset "KineticForcesState" begin


### PR DESCRIPTION
Closes #248.

## Problem

`src/KineticForces/` enumerated the same 18 NTV methods, in the same order, in three (really four) position-coupled places that had to be hand-kept in lockstep:

1. `KineticForcesInternal.methods` (names) + `.docs` (doc strings) vectors
2. The `flags = [...]` array in `Compute.jl`, indexed `flags[m]` against `intr.methods[m]`/`intr.docs[m]`
3. The hardcoded `elseif method in ["fgar", …, "prmm"]` dispatch list in `Torque.jl`

The positional coupling in (2) was the real hazard: a single transposed or omitted entry silently paired the wrong boolean/doc with the wrong method and would produce wrong-but-plausible NTV output. The old guard test only checked `length == 18`, which would pass even with two flags swapped.

## Change

A single `const METHOD_REGISTRY` in `KineticForcesStructs.jl` of `(name, flag, kind, doc)` NamedTuples is now the one place the methods are enumerated:

- `Compute.jl` iterates the registry and reads each flag via `getfield(ctrl, entry.flag)` — the `flags` array and `methods`/`docs` vectors are gone.
- `Torque.jl` routes on the `kind` tag (`:gar`/`:fcgl`/`:rlar`/`:clar`) via a new `method_kind` helper, replacing the hardcoded membership list and `else error(...)`.
- The 18 `*_flag` struct fields on `KineticForcesControl` stay — the TOML kwargs splat (`KineticForcesControl(; (Symbol(k) => v …)...)`) and direct `ctrl.fgar_flag` accesses require them.

The length-guard test is replaced with a structural test asserting every registry `flag` is a real `KineticForcesControl` field with a recognized `kind` and round-trips through `method_kind` — no fixed count, so adding a method needs no magic-number edit.

Drift surfaces drop from 3+ to 1.

## Verification

- **Unit tests:** 190/190 pass (`runtests_kinetic.jl`), including the new `METHOD_REGISTRY` testset.
- **Regression harness** (`solovev_kinetic_calculated`, local vs develop): **15/15 quantities identical (0.0e+00 / OK)**. The case exercises the NTV dispatch (nonzero kinetic `Im(et[1])`), confirming the refactor is numerically inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)