### PR TITLE
VACUUM - Some small cleanups

### DIFF
--- a/examples/Solovev_ideal_example_3D/gpec.toml
+++ b/examples/Solovev_ideal_example_3D/gpec.toml
@@ -21,7 +21,7 @@ mat_flag = true               # Construct coefficient matrices for diagnostic pu
 ode_flag = true               # Integrate ODEs for stability of the internal long-wavelength mode (must be true for GPEC)
 vac_flag = true               # Compute plasma, vacuum, and total energies for free-boundary modes
 
-psiedge = 0.99                # Edge dW(ψ) diagnostic scan band [psiedge, psilim]; set ≥ psilim to disable
+psiedge = 1.0                # Edge dW(ψ) diagnostic scan band [psiedge, psilim]; set ≥ psilim to disable
 qlow = 1.02                   # Integration initiated at q determined by min(q0, qlow)
 qhigh = 1e3                   # Integration terminated at q limit determined by min(qa, qhigh)
 sing_start = 0                # Start integration at the sing_start'th rational from the axis (psilow)
@@ -30,8 +30,8 @@ nn_low = 1                    # Smallest toroidal mode number to include
 nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
-delta_mband = 0               # Integration keeps only this wide a band...
-mthvac = 96                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
+mthvac = 64                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
+nzvac = 96                    # Number of points used in splines over toroidal angle at the plasma-vacuum interface
 thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model

--- a/examples/Solovev_ideal_example_3D/run_example.jl
+++ b/examples/Solovev_ideal_example_3D/run_example.jl
@@ -1,0 +1,4 @@
+using Pkg;
+Pkg.activate(joinpath(@__DIR__, "../.."))
+using GeneralizedPerturbedEquilibrium
+GeneralizedPerturbedEquilibrium.main([dirname(@__FILE__)])

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -66,50 +66,50 @@ Bundles all necessary settings originally specified in the equil fortran namelis
         force_termination, use_galgrid, imas_cocos)
         if jac_type == "hamada"
             @info "Forcing hamada coordinate jacobian exponents: power_*"
-            power_b = 0;
-            power_bp = 0;
-            power_r = 0;
+            power_b = 0
+            power_bp = 0
+            power_r = 0
             power_rc = 0
         elseif jac_type == "pest"
             @info "Forcing pest coordinate jacobian exponents: power_*"
-            power_b = 0;
-            power_bp = 0;
-            power_r = 2;
+            power_b = 0
+            power_bp = 0
+            power_r = 2
             power_rc = 0
         elseif jac_type == "equal_arc"
             @info "Forcing equal_arc coordinate jacobian exponents: power_*"
-            power_b = 0;
-            power_bp = 1;
-            power_r = 0;
+            power_b = 0
+            power_bp = 1
+            power_r = 0
             power_rc = 0
         elseif jac_type == "boozer"
             @info "Forcing boozer coordinate jacobian exponents: power_*"
-            power_b = 2;
-            power_bp = 0;
-            power_r = 0;
+            power_b = 2
+            power_bp = 0
+            power_r = 0
             power_rc = 0
         elseif jac_type == "park"
             @info "Forcing park coordinate jacobian exponents: power_*"
-            power_b = 1;
-            power_bp = 0;
-            power_r = 0;
+            power_b = 1
+            power_bp = 0
+            power_r = 0
             power_rc = 0
         elseif jac_type == "other"
             # Normalize to a named type when the powers match, so fast paths are taken.
             if power_b == 0 && power_bp == 0 && power_r == 0 && power_rc == 0
-                jac_type = "hamada";
+                jac_type = "hamada"
                 @info "Recognized hamada jacobian from power exponents"
             elseif power_b == 0 && power_bp == 0 && power_r == 2 && power_rc == 0
-                jac_type = "pest";
+                jac_type = "pest"
                 @info "Recognized pest jacobian from power exponents"
             elseif power_b == 0 && power_bp == 1 && power_r == 0 && power_rc == 0
-                jac_type = "equal_arc";
+                jac_type = "equal_arc"
                 @info "Recognized equal_arc jacobian from power exponents"
             elseif power_b == 2 && power_bp == 0 && power_r == 0 && power_rc == 0
-                jac_type = "boozer";
+                jac_type = "boozer"
                 @info "Recognized boozer jacobian from power exponents"
             elseif power_b == 1 && power_bp == 0 && power_r == 0 && power_rc == 0
-                jac_type = "park";
+                jac_type = "park"
                 @info "Recognized park jacobian from power exponents"
             else
                 @info "Using manual jacobian exponents: power b, bp, r, rc = $(power_b), $(power_bp), $(power_r), $(power_rc)"

--- a/src/ForceFreeStates/Free.jl
+++ b/src/ForceFreeStates/Free.jl
@@ -32,10 +32,7 @@ and data dumping.
 
     # Scale by (m - n*q)(m' - n'*q) [Chance Phys. Plasmas 1997 2161 eq. 126]
     singfac = vec((mlow:mhigh) .- qlim .* (nlow:nhigh)')
-    @inbounds for ipert in 1:numpert_total
-        @views vac_data.wv[ipert, :] .*= singfac[ipert]
-        @views vac_data.wv[:, ipert] .*= singfac[ipert]
-    end
+    vac_data.wv .*= singfac .* singfac'
 
     # Least stable eigenvalue of the vacuum matrix alone (should be PSD; clamp numerical noise to zero)
     vac_data.vacuum_eigenvalue = max(0.0, minimum(real.(eigvals(Hermitian(vac_data.wv)))))
@@ -83,16 +80,14 @@ and data dumping.
         vac_data.wt[:, isol] .*= phase
     end
 
-    # Compute plasma and vacuum contributions.
-    # wpt = wt' * wp * wt  ; wvt = wt' * wv * wt
+    # Project W_p and W_v into the eigenmode basis. Diagonal entries give
+    # the plasma/vacuum energy split for each mode: et[i] = ep[i] + ev[i]
     mul!(tmp_mat, wp, vac_data.wt)
-    mul!(wpt, adjoint(vac_data.wt), tmp_mat)
+    mul!(wpt, vac_data.wt', tmp_mat)
     mul!(tmp_mat, vac_data.wv, vac_data.wt)
-    mul!(wvt, adjoint(vac_data.wt), tmp_mat)
-    for ipert in 1:numpert_total
-        vac_data.ep[ipert] = wpt[ipert, ipert]
-        vac_data.ev[ipert] = wvt[ipert, ipert]
-    end
+    mul!(wvt, vac_data.wt', tmp_mat)
+    vac_data.ep .= diag(wpt)
+    vac_data.ev .= diag(wvt)
 
     # Eigenspectrum of W_Φ at psilim — Jacobian-invariant energy values; see RootAreaWeighted.jl.
     # Computed directly here (no spline); spline is used by the edge scan.
@@ -141,7 +136,7 @@ Compute a spline of vacuum response matrices over the range of psi from 'ctrl.ps
 same function as `free_wvmats` in the Fortran code. Currently defaults to 4 spline points per
 q-window minimum.
 """
-function free_compute_wv_spline(ctrl::ForceFreeStatesControl, equil::Equilibrium.PlasmaEquilibrium, intr::ForceFreeStatesInternal)
+@with_pool pool function free_compute_wv_spline(ctrl::ForceFreeStatesControl, equil::Equilibrium.PlasmaEquilibrium, intr::ForceFreeStatesInternal)
 
     profiles = equil.profiles
 
@@ -149,8 +144,8 @@ function free_compute_wv_spline(ctrl::ForceFreeStatesControl, equil::Equilibrium
     # TODO: 4 spline points is arbitrary - is there a better way?
     qedge = profiles.q_spline(ctrl.psiedge)
     npsi = max(4, ceil(Int, (intr.qlim - qedge) * intr.nhigh * 4))
-    psi_array = zeros(Float64, npsi + 1)
-    wv_array = zeros(ComplexF64, npsi + 1, intr.numpert_total, intr.numpert_total)
+    psi_array = zeros!(pool, Float64, npsi + 1)
+    wv_array = zeros!(pool, ComplexF64, npsi + 1, intr.numpert_total, intr.numpert_total)
 
     for i in 1:(npsi+1)
         # Space points evenly in q over [qedge, qlim] (i=1 → qedge, i=npsi+1 → qlim)
@@ -212,10 +207,7 @@ wv matrix spline to `free_compute_wv_spline` and pass it in `odet.edge_scan.wvma
     q_at_psifac = equil.profiles.q_spline(odet.psifac)
     # Scale by (m - n*q)(m' - n'*q) [Chance Phys. Plasmas 1997 2161 eq. 126]
     singfac = vec((intr.mlow:intr.mhigh) .- q_at_psifac .* (intr.nlow:intr.nhigh)')
-    @inbounds for ipert in 1:Npert
-        @views wv[ipert, :] .*= singfac[ipert]
-        @views wv[:, ipert] .*= singfac[ipert]
-    end
+    wv .*= singfac .* singfac'
 
     # Compute total energy matrix and eigen-decomposition
     wt .= wp .+ wv

--- a/src/PerturbedEquilibrium/FieldReconstruction.jl
+++ b/src/PerturbedEquilibrium/FieldReconstruction.jl
@@ -670,11 +670,11 @@ function compute_cova_components(
 
         # Tensor contraction with mode coupling (matches Fortran gpeq_cova)
         for ipert in 1:mpert
-            xvp_acc = zero(ComplexF64);
-            xvt_acc = zero(ComplexF64);
+            xvp_acc = zero(ComplexF64)
+            xvt_acc = zero(ComplexF64)
             xvz_acc = zero(ComplexF64)
-            bvp_acc = zero(ComplexF64);
-            bvt_acc = zero(ComplexF64);
+            bvp_acc = zero(ComplexF64)
+            bvt_acc = zero(ComplexF64)
             bvz_acc = zero(ComplexF64)
 
             for dm in (1-ipert):(mpert-ipert)
@@ -916,9 +916,9 @@ function _build_rzphi_geometry(
                 v21 = dr2_dtheta / (2 * rfac)
                 v22 = (1 + doff_dtheta) * 2π * rfac
             else
-                v11 = 0.0;
-                v12 = 0.0;
-                v21 = 0.0;
+                v11 = 0.0
+                v12 = 0.0
+                v21 = 0.0
                 v22 = 0.0
             end
 

--- a/src/PerturbedEquilibrium/Response.jl
+++ b/src/PerturbedEquilibrium/Response.jl
@@ -7,11 +7,12 @@
 Compute plasma response to external forcing using ForceFreeStates eigenmode solutions.
 
 Implements resp_index=0 calculation from Fortran gpresp:
-- Build flux matrix from eigenmodes
-- Calculate plasma inductance Lambda (wt0-based, resp_induct_flag=TRUE)
-- Calculate surface inductance L from Green's function
-- Compute permeability P = Lambda * L^{-1}
-- Apply forcing to get response: Phi_tot = P * Phi_x
+
+  - Build flux matrix from eigenmodes
+  - Calculate plasma inductance Lambda (wt0-based, resp_induct_flag=TRUE)
+  - Calculate surface inductance L from Green's function
+  - Compute permeability P = Lambda * L^{-1}
+  - Apply forcing to get response: Phi_tot = P * Phi_x
 """
 function compute_plasma_response!(
     state::PerturbedEquilibriumState,
@@ -40,10 +41,9 @@ function compute_plasma_response!(
     # vac_data.grri has shape [2*mthvac*nzvac, 2*mpert] and cannot be used directly.
     nn = ffs_intr.nlow
     vac_input_2d = Vacuum.VacuumInput(equil, ffs_intr.psilim, vac_data.mthvac, 1,
-                                      ffs_intr.mpert, ffs_intr.mlow, 1, nn)
+        ffs_intr.mpert, ffs_intr.mlow, 1, nn)
     wall_nowall = Vacuum.WallShapeSettings(; shape="nowall")
-    _, grri_2d_raw, grre_2d_raw, _, _ = Vacuum.compute_vacuum_response(
-        vac_input_2d, wall_nowall; green_only=true)
+    _, grri_2d_raw, grre_2d_raw, _, _ = Vacuum.compute_vacuum_response(vac_input_2d, wall_nowall)
     grri_2d = Matrix{Float64}(grri_2d_raw)
     grre_2d = Matrix{Float64}(grre_2d_raw)
     ν_vac = Vacuum.PlasmaGeometry(vac_input_2d).ν
@@ -66,30 +66,30 @@ function compute_plasma_response!(
     # flux (Φ = A·b̄) — see Utils.jl output docs.
     rootarea_to_area_weight, surface_area = build_control_surface_rootarea_to_area_weight(equil, ffs_intr)
     field_mats = field_space_response_matrices(plasma_inductance, surface_inductance, permeability, reluctance, rootarea_to_area_weight, surface_area)
-    state.plasma_inductance       = field_mats.plasma_inductance
-    state.surface_inductance      = field_mats.surface_inductance
-    state.permeability            = field_mats.permeability
-    state.reluctance              = field_mats.reluctance
+    state.plasma_inductance = field_mats.plasma_inductance
+    state.surface_inductance = field_mats.surface_inductance
+    state.permeability = field_mats.permeability
+    state.reluctance = field_mats.reluctance
     state.rootarea_to_area_weight = rootarea_to_area_weight
-    state.surface_area            = surface_area
+    state.surface_area = surface_area
 
     # Forcing and response on the control surface. Flux Φ appears only as a brief internal bridge:
     # forcing arrives as Φ_x, the field reconstruction below consumes Φ_tot, and the b̃ spectra are
     # formed via the conform operator R = S·A (Φ = R·b̃).
-    forcing_flux  = map_forcing_to_eigenmodes(intr.forcing_modes, ffs_intr)
+    forcing_flux = map_forcing_to_eigenmodes(intr.forcing_modes, ffs_intr)
     response_flux = compute_plasma_response_vector(permeability, forcing_flux)
 
     # Output forcing/response in the three Pharr field representations (all tesla):
     #   b̃ (root-area-weighted) = R⁻¹·Φ,  b (bare) = Σ⁻¹·b̃,  b̄ (area-weighted) = S·b̃.
-    flux_conform     = rootarea_to_area_weight .* surface_area          # R = Σ·√A  (b̃ → flux)
+    flux_conform = rootarea_to_area_weight .* surface_area          # R = Σ·√A  (b̃ → flux)
     bare_to_rootarea = rootarea_to_area_weight .* sqrt(surface_area)    # Σ        (bare → b̃)
-    forcing_b_rootarea  = flux_conform \ forcing_flux
+    forcing_b_rootarea = flux_conform \ forcing_flux
     response_b_rootarea = flux_conform \ response_flux
-    state.forcing_b_rootarea  = forcing_b_rootarea
+    state.forcing_b_rootarea = forcing_b_rootarea
     state.response_b_rootarea = response_b_rootarea
-    state.forcing_b   = bare_to_rootarea \ forcing_b_rootarea
-    state.response_b  = bare_to_rootarea \ response_b_rootarea
-    state.forcing_b_area  = rootarea_to_area_weight * forcing_b_rootarea
+    state.forcing_b = bare_to_rootarea \ forcing_b_rootarea
+    state.response_b = bare_to_rootarea \ response_b_rootarea
+    state.forcing_b_area = rootarea_to_area_weight * forcing_b_rootarea
     state.response_b_area = rootarea_to_area_weight * response_b_rootarea
 
     # Scalar energies and torque (Joules), ported from Fortran gpout. These are congruence-invariant
@@ -98,12 +98,12 @@ function compute_plasma_response!(
     # needlessly ill-conditioned. The result is a physical scalar, not a stored flux quantity.
     L_surf_inv = inv(surface_inductance)
     L_plas_inv = inv(plasma_inductance)
-    vy = dot(forcing_flux,  L_surf_inv * forcing_flux)  / 4
+    vy = dot(forcing_flux, L_surf_inv * forcing_flux) / 4
     sy = dot(response_flux, L_surf_inv * response_flux) / 4
     py = dot(response_flux, L_plas_inv * response_flux) / 4
-    state.vacuum_energy   = real(vy)
-    state.surface_energy  = real(sy)
-    state.plasma_energy   = real(py)              # Fortran's "total energy" is this pengy
+    state.vacuum_energy = real(vy)
+    state.surface_energy = real(sy)
+    state.plasma_energy = real(py)              # Fortran's "total energy" is this pengy
     state.toroidal_torque = -2 * nn * imag(py)
 
     xi_modes, b_modes = reconstruct_physical_fields(
@@ -114,12 +114,12 @@ function compute_plasma_response!(
     npsi = size(ForceFreeStates_results.u_store, 4)
     state.psi_grid = ForceFreeStates_results.psi_store[1:npsi]
     state.xi_modes = xi_modes
-    state.b_modes  = b_modes
+    state.b_modes = b_modes
 
     b_n_modes, xi_n_modes = compute_b_n_xi_n_modes(
         xi_modes.psi_J, b_modes.psi, ForceFreeStates_results, equil, ffs_intr
     )
-    state.b_n_modes  = b_n_modes
+    state.b_n_modes = b_n_modes
     state.xi_n_modes = xi_n_modes
 
     if ctrl.verbose

--- a/src/PerturbedEquilibrium/SingularCoupling.jl
+++ b/src/PerturbedEquilibrium/SingularCoupling.jl
@@ -33,9 +33,9 @@ end
 function _hermite_cubic_val(u_a, u_b, du_a, du_b, psi_a, psi_b, psi)
     h = psi_b - psi_a
     t = (psi - psi_a) / h
-    h00 = 2t^3 - 3t^2 + 1;
+    h00 = 2t^3 - 3t^2 + 1
     h10 = t^3 - 2t^2 + t
-    h01 = -2t^3 + 3t^2;
+    h01 = -2t^3 + 3t^2
     h11 = t^3 - t^2
     return @. h00 * u_a + h * h10 * du_a + h01 * u_b + h * h11 * du_b
 end
@@ -203,18 +203,18 @@ function compute_singular_coupling_metrics!(
 
         u_node = ForceFreeStates_results.u_store
         ud_node = ForceFreeStates_results.ud_store
-        ua_l = u_node[resnum, :, 1, il_l];
+        ua_l = u_node[resnum, :, 1, il_l]
         ub_l = u_node[resnum, :, 1, ir_l]
-        ua_r = u_node[resnum, :, 1, il_r];
+        ua_r = u_node[resnum, :, 1, il_r]
         ub_r = u_node[resnum, :, 1, ir_r]
-        dua_l = ud_node[resnum, :, 1, il_l];
+        dua_l = ud_node[resnum, :, 1, il_l]
         dub_l = ud_node[resnum, :, 1, ir_l]
-        dua_r = ud_node[resnum, :, 1, il_r];
+        dua_r = ud_node[resnum, :, 1, il_r]
         dub_r = ud_node[resnum, :, 1, ir_r]
 
-        psi_il_l = psi_store_all[il_l];
+        psi_il_l = psi_store_all[il_l]
         psi_ir_l = psi_store_all[ir_l]
-        psi_il_r = psi_store_all[il_r];
+        psi_il_r = psi_store_all[il_r]
         psi_ir_r = psi_store_all[ir_r]
 
         u_l = _hermite_cubic_val(ua_l, ub_l, dua_l, dub_l, psi_il_l, psi_ir_l, lpsi)
@@ -226,9 +226,9 @@ function compute_singular_coupling_metrics!(
         ud_l = (ub_l .- ua_l) ./ (psi_ir_l - psi_il_l)
         ud_r = (ub_r .- ua_r) ./ (psi_ir_r - psi_il_r)
 
-        q_l = equil.profiles.q_spline(lpsi);
+        q_l = equil.profiles.q_spline(lpsi)
         q1_l = equil.profiles.q_deriv(lpsi)
-        q_r = equil.profiles.q_spline(rpsi);
+        q_r = equil.profiles.q_spline(rpsi)
         q1_r = equil.profiles.q_deriv(rpsi)
         singfac_l = m_res - nn * q_l
         singfac_r = m_res - nn * q_r
@@ -236,9 +236,9 @@ function compute_singular_coupling_metrics!(
         jump_vec = Vector{ComplexF64}(undef, numpert_total)
         for k in 1:numpert_total
             ck = @view C_coeffs[:, k]
-            xsp_l = dot(u_l, ck);
+            xsp_l = dot(u_l, ck)
             xsp1_l = dot(ud_l, ck)
-            xsp_r = dot(u_r, ck);
+            xsp_r = dot(u_r, ck)
             xsp1_r = dot(ud_r, ck)
             bwp1_l = 2π * im * chi1 * (singfac_l * xsp1_l - nn * q1_l * xsp_l)
             bwp1_r = 2π * im * chi1 * (singfac_r * xsp1_r - nn * q1_r * xsp_r)

--- a/src/PerturbedEquilibrium/SingularCoupling.jl
+++ b/src/PerturbedEquilibrium/SingularCoupling.jl
@@ -33,8 +33,10 @@ end
 function _hermite_cubic_val(u_a, u_b, du_a, du_b, psi_a, psi_b, psi)
     h = psi_b - psi_a
     t = (psi - psi_a) / h
-    h00 = 2t^3 - 3t^2 + 1;  h10 = t^3 - 2t^2 + t
-    h01 = -2t^3 + 3t^2;     h11 = t^3 - t^2
+    h00 = 2t^3 - 3t^2 + 1;
+    h10 = t^3 - 2t^2 + t
+    h01 = -2t^3 + 3t^2;
+    h11 = t^3 - t^2
     return @. h00 * u_a + h * h10 * du_a + h01 * u_b + h * h11 * du_b
 end
 
@@ -61,15 +63,17 @@ Matching Fortran GPEC output: `C_f_x_out` (coupling matrix) and `Phi_res`, `w_is
 
 Populates `state` with:
 
-  Coupling matrices `[n_rational × numpert_total]` — C[row, j] = coupling when forcing mode j has unit amplitude:
+Coupling matrices `[n_rational × numpert_total]` — C[row, j] = coupling when forcing mode j has unit amplitude:
+
   - `C_resonant_area_weighted_field`, `C_resonant_current`, `C_island_width_sq`, `C_penetrated_area_weighted_field`, `C_delta_prime`
 
-  Applied resonant vectors `[n_rational]` = C · amp_vec:
+Applied resonant vectors `[n_rational]` = C · amp_vec:
+
   - `resonant_area_weighted_field`, `resonant_current`, `island_width_sq`, `penetrated_area_weighted_field`, `delta_prime`
 
-  Diagnostics `[n_rational]`: `island_half_width`, `chirikov_parameter`
+Diagnostics `[n_rational]`: `island_half_width`, `chirikov_parameter`
 
-  Metadata `[n_rational]`: `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
+Metadata `[n_rational]`: `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
 """
 function compute_singular_coupling_metrics!(
     state::PerturbedEquilibriumState,
@@ -125,15 +129,15 @@ function compute_singular_coupling_metrics!(
     ctrl.verbose && @info "Found $n_rational resonant (surface, n) pairs"
 
     # Phase 2: Allocate output arrays
-    state.C_resonant_area_weighted_field     = zeros(ComplexF64, n_rational, numpert_total)
-    state.C_resonant_current   = zeros(ComplexF64, n_rational, numpert_total)
-    state.C_island_width_sq    = zeros(ComplexF64, n_rational, numpert_total)
-    state.C_penetrated_area_weighted_field   = zeros(ComplexF64, n_rational, numpert_total)
-    state.C_delta_prime        = zeros(ComplexF64, n_rational, numpert_total)
-    state.rational_psi         = zeros(Float64, n_rational)
-    state.rational_q           = zeros(Float64, n_rational)
-    state.rational_m_res       = zeros(Int, n_rational)
-    state.rational_n           = zeros(Int, n_rational)
+    state.C_resonant_area_weighted_field = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_resonant_current = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_island_width_sq = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_penetrated_area_weighted_field = zeros(ComplexF64, n_rational, numpert_total)
+    state.C_delta_prime = zeros(ComplexF64, n_rational, numpert_total)
+    state.rational_psi = zeros(Float64, n_rational)
+    state.rational_q = zeros(Float64, n_rational)
+    state.rational_m_res = zeros(Int, n_rational)
+    state.rational_n = zeros(Int, n_rational)
     state.rational_surface_idx = zeros(Int, n_rational)
 
     # Precompute ODE coefficient matrix C_coeffs for all PE forcing modes.
@@ -141,9 +145,9 @@ function compute_singular_coupling_metrics!(
     # where edge_mn_k[j] = plasma_response[j,k] / (chi1·singfac_lim[j]·2πi)
     # Matches Fortran gpout_resp: edge_mn = foutmn/(chi1·singfac·twopi·ifac)
     psi_lim = ForceFreeStates_results.psi_store[ForceFreeStates_results.step]
-    q_lim   = equil.profiles.q_spline(psi_lim)
+    q_lim = equil.profiles.q_spline(psi_lim)
     singfac_lim = [intr.m_modes[j] - intr.n_modes[j] * q_lim for j in 1:numpert_total]
-    u_bnd   = ForceFreeStates_results.u_store[:, :, 1, ForceFreeStates_results.step]
+    u_bnd = ForceFreeStates_results.u_store[:, :, 1, ForceFreeStates_results.step]
     # Divide each row j by singfac_lim[j] — reshape to column vector so Julia broadcasts row-wise, not column-wise.
     edge_mn = intr.plasma_response ./ (chi1 * 2π * im .* reshape(singfac_lim, :, 1))
     C_coeffs = u_bnd \ edge_mn  # mpert × numpert_total
@@ -163,7 +167,7 @@ function compute_singular_coupling_metrics!(
 
         # Compute Green's functions at this surface for this n (once per pair)
         vac_input = Vacuum.VacuumInput(equil, sing_surf.psifac, mtheta, 1, mpert, mlow, 1, nn)
-        _, grri_raw, grre_raw, _, _ = Vacuum.compute_vacuum_response(vac_input, wall_settings; green_only=true)
+        _, grri_raw, grre_raw, _, _ = Vacuum.compute_vacuum_response(vac_input, wall_settings)
         grri = Matrix{Float64}(grri_raw)
         grre = Matrix{Float64}(grre_raw)
         ffs_intr.sing[s].grri = grri
@@ -177,8 +181,8 @@ function compute_singular_coupling_metrics!(
         m_idx = m_res - mlow + 1
         L_mm = L_surf[m_idx, m_idx]
 
-        j_c   = compute_current_density(equil, sing_surf.psifac)
-        area  = compute_surface_area(equil, sing_surf.psifac)
+        j_c = compute_current_density(equil, sing_surf.psifac)
+        area = compute_surface_area(equil, sing_surf.psifac)
         # Matches Fortran gpout_resp: shear = m*dq/dψ / q² = n*dq/dψ / q (since m=n*q).
         # Uses abs(nn) because island_half_width = sqrt(abs(island_width_sq)), so the sign
         # of shear only affects the sign of C_island_width_sq, not the physical island width.
@@ -197,18 +201,24 @@ function compute_singular_coupling_metrics!(
         il_l, ir_l, _ = _psi_bracket(psi_store_all, lpsi, nstep)
         il_r, ir_r, _ = _psi_bracket(psi_store_all, rpsi, nstep)
 
-        u_node  = ForceFreeStates_results.u_store
+        u_node = ForceFreeStates_results.u_store
         ud_node = ForceFreeStates_results.ud_store
-        ua_l = u_node[ resnum, :, 1, il_l];  ub_l = u_node[ resnum, :, 1, ir_l]
-        ua_r = u_node[ resnum, :, 1, il_r];  ub_r = u_node[ resnum, :, 1, ir_r]
-        dua_l = ud_node[resnum, :, 1, il_l]; dub_l = ud_node[resnum, :, 1, ir_l]
-        dua_r = ud_node[resnum, :, 1, il_r]; dub_r = ud_node[resnum, :, 1, ir_r]
+        ua_l = u_node[resnum, :, 1, il_l];
+        ub_l = u_node[resnum, :, 1, ir_l]
+        ua_r = u_node[resnum, :, 1, il_r];
+        ub_r = u_node[resnum, :, 1, ir_r]
+        dua_l = ud_node[resnum, :, 1, il_l];
+        dub_l = ud_node[resnum, :, 1, ir_l]
+        dua_r = ud_node[resnum, :, 1, il_r];
+        dub_r = ud_node[resnum, :, 1, ir_r]
 
-        psi_il_l = psi_store_all[il_l];  psi_ir_l = psi_store_all[ir_l]
-        psi_il_r = psi_store_all[il_r];  psi_ir_r = psi_store_all[ir_r]
+        psi_il_l = psi_store_all[il_l];
+        psi_ir_l = psi_store_all[ir_l]
+        psi_il_r = psi_store_all[il_r];
+        psi_ir_r = psi_store_all[ir_r]
 
-        u_l  = _hermite_cubic_val(ua_l, ub_l, dua_l, dub_l, psi_il_l, psi_ir_l, lpsi)
-        u_r  = _hermite_cubic_val(ua_r, ub_r, dua_r, dub_r, psi_il_r, psi_ir_r, rpsi)
+        u_l = _hermite_cubic_val(ua_l, ub_l, dua_l, dub_l, psi_il_l, psi_ir_l, lpsi)
+        u_r = _hermite_cubic_val(ua_r, ub_r, dua_r, dub_r, psi_il_r, psi_ir_r, rpsi)
         # Derivative (ud): chord slope from u_store only — ud_store can be systematically off near
         # outer surfaces (q=4/5) where the ODE solution varies rapidly; near-cancellation in bwp1
         # then amplifies even a ~10% ud_store error into a large Delta' error. Chord slope avoids
@@ -216,16 +226,20 @@ function compute_singular_coupling_metrics!(
         ud_l = (ub_l .- ua_l) ./ (psi_ir_l - psi_il_l)
         ud_r = (ub_r .- ua_r) ./ (psi_ir_r - psi_il_r)
 
-        q_l = equil.profiles.q_spline(lpsi);  q1_l = equil.profiles.q_deriv(lpsi)
-        q_r = equil.profiles.q_spline(rpsi);  q1_r = equil.profiles.q_deriv(rpsi)
+        q_l = equil.profiles.q_spline(lpsi);
+        q1_l = equil.profiles.q_deriv(lpsi)
+        q_r = equil.profiles.q_spline(rpsi);
+        q1_r = equil.profiles.q_deriv(rpsi)
         singfac_l = m_res - nn * q_l
         singfac_r = m_res - nn * q_r
 
         jump_vec = Vector{ComplexF64}(undef, numpert_total)
         for k in 1:numpert_total
-            ck    = @view C_coeffs[:, k]
-            xsp_l  = dot(u_l,  ck);  xsp1_l = dot(ud_l, ck)
-            xsp_r  = dot(u_r,  ck);  xsp1_r = dot(ud_r, ck)
+            ck = @view C_coeffs[:, k]
+            xsp_l = dot(u_l, ck);
+            xsp1_l = dot(ud_l, ck)
+            xsp_r = dot(u_r, ck);
+            xsp1_r = dot(ud_r, ck)
             bwp1_l = 2π * im * chi1 * (singfac_l * xsp1_l - nn * q1_l * xsp_l)
             bwp1_r = 2π * im * chi1 * (singfac_r * xsp1_r - nn * q1_r * xsp_r)
             jump_vec[k] = bwp1_r - bwp1_l
@@ -245,7 +259,7 @@ function compute_singular_coupling_metrics!(
         #  - resonant (shielding) current: j_c already integrates jac·|∇ψ| over the surface, so the
         #    Jacobian weighting is carried inside j_c — no separate area factor needed.
         #  - resonant flux → field: Φ^r/A^r [T], invariant [Park 2008; Pharr 2026].
-        state.C_delta_prime[row, :]      = jump_vec ./ (twopi * chi1)
+        state.C_delta_prime[row, :] = jump_vec ./ (twopi * chi1)
         state.C_resonant_current[row, :] = jump_vec .* (-j_c / (twopi * m_res))
         # Matches Fortran gpout_resp: singflx = L·fkaxmn, resonant area-weighted field = singflx/area,
         # islandhwids = 4·singflx/(2π·shear·q·chi1)
@@ -255,11 +269,11 @@ function compute_singular_coupling_metrics!(
             state.C_island_width_sq[row, :] = (4.0 / (twopi * shear * sing_surf.q * chi1)) .* singflx_pre
         end
 
-        state.rational_psi[row]          = sing_surf.psifac
-        state.rational_q[row]            = sing_surf.q
-        state.rational_m_res[row]        = m_res
-        state.rational_n[row]            = nn
-        state.rational_surface_idx[row]  = s
+        state.rational_psi[row] = sing_surf.psifac
+        state.rational_q[row] = sing_surf.q
+        state.rational_m_res[row] = m_res
+        state.rational_n[row] = nn
+        state.rational_surface_idx[row] = s
 
         if ctrl.verbose
             dp_diag = real(state.C_delta_prime[row, resnum])
@@ -276,11 +290,11 @@ function compute_singular_coupling_metrics!(
         isnothing(j) || (forcing_flux[j] = mode.amplitude)
     end
 
-    state.resonant_area_weighted_field   = state.C_resonant_area_weighted_field   * forcing_flux
+    state.resonant_area_weighted_field = state.C_resonant_area_weighted_field * forcing_flux
     state.resonant_current = state.C_resonant_current * forcing_flux
-    state.island_width_sq  = state.C_island_width_sq  * forcing_flux
+    state.island_width_sq = state.C_island_width_sq * forcing_flux
     state.penetrated_area_weighted_field = state.C_penetrated_area_weighted_field * forcing_flux
-    state.delta_prime      = state.C_delta_prime      * forcing_flux
+    state.delta_prime = state.C_delta_prime * forcing_flux
 
     # Conform the stored coupling-matrix input basis to the coordinate-invariant root-area-weighted
     # field (b̃) space (#233 / Pharr 2026): C̃ = C·R, so each stored row acts on the applied field
@@ -290,18 +304,18 @@ function compute_singular_coupling_metrics!(
     # scalars carry no round-trip noise.
     rootarea_to_area_weight, surface_area = build_control_surface_rootarea_to_area_weight(equil, ffs_intr)
     flux_conform = rootarea_to_area_weight .* surface_area
-    state.C_resonant_area_weighted_field   = state.C_resonant_area_weighted_field   * flux_conform
+    state.C_resonant_area_weighted_field = state.C_resonant_area_weighted_field * flux_conform
     state.C_resonant_current = state.C_resonant_current * flux_conform
-    state.C_island_width_sq  = state.C_island_width_sq  * flux_conform
+    state.C_island_width_sq = state.C_island_width_sq * flux_conform
     state.C_penetrated_area_weighted_field = state.C_penetrated_area_weighted_field * flux_conform
-    state.C_delta_prime      = state.C_delta_prime      * flux_conform
+    state.C_delta_prime = state.C_delta_prime * flux_conform
 
     # Phase 5: Island diagnostics from applied resonant vectors
     compute_island_diagnostics!(state, n_rational)
 
     if ctrl.verbose
         max_island = isempty(state.island_half_width) ? 0.0 : maximum(state.island_half_width)
-        max_dp     = isempty(state.delta_prime)       ? 0.0 : maximum(abs.(real.(state.delta_prime)))
+        max_dp = isempty(state.delta_prime) ? 0.0 : maximum(abs.(real.(state.delta_prime)))
         @info "Singular coupling complete. Max island half-width = $(@sprintf("%.3e", max_island)), max |Δ'| = $(@sprintf("%.3e", max_dp))"
     end
 end
@@ -443,7 +457,7 @@ Surface inductance matrix [mpert × mpert]
     grre::Matrix{Float64},
     ffs_intr::ForceFreeStatesInternal,
     nn::Int,
-    ν::Vector{Float64},
+    ν::Vector{Float64}
 )::Matrix{ComplexF64}
     mpert = ffs_intr.mpert
     mtheta = size(grri, 1) ÷ 2
@@ -451,7 +465,7 @@ Surface inductance matrix [mpert × mpert]
 
     ft = FourierTransforms.FourierTransform(mtheta, mpert, ffs_intr.mlow)
 
-    flux_matrix    = zeros!(pool, ComplexF64, mpert, mpert)
+    flux_matrix = zeros!(pool, ComplexF64, mpert, mpert)
     current_matrix = zeros!(pool, ComplexF64, mpert, mpert)
 
     grri_surf = @view grri[1:mtheta, :]
@@ -469,8 +483,8 @@ Surface inductance matrix [mpert × mpert]
         flux_matrix[i, i] = 1.0
 
         for k in 1:mtheta
-            kax_re[k] = (grri_surf[k, i]        + grre_surf[k, i])        / (μ₀ * (2π)^2)
-            kax_im[k] = (grri_surf[k, mpert+i]  + grre_surf[k, mpert+i])  / (μ₀ * (2π)^2)
+            kax_re[k] = (grri_surf[k, i] + grre_surf[k, i]) / (μ₀ * (2π)^2)
+            kax_im[k] = (grri_surf[k, mpert+i] + grre_surf[k, mpert+i]) / (μ₀ * (2π)^2)
         end
 
         # Port of Fortran gpvacuum_flxsurf: apply the toroidal phase exp(-i*n*ν),
@@ -562,13 +576,13 @@ Compute island half-width and Chirikov parameter from applied resonant vectors.
   - `chirikov_parameter[row]` = half-width / (half-distance to nearest neighbor in rational_psi)
 """
 function compute_island_diagnostics!(state::PerturbedEquilibriumState, n_rational::Int)
-    state.island_half_width  = sqrt.(abs.(state.island_width_sq))
+    state.island_half_width = sqrt.(abs.(state.island_width_sq))
     state.chirikov_parameter = zeros(Float64, n_rational)
 
     n_rational <= 1 && return
 
     for row in 1:n_rational
-        psi_row  = state.rational_psi[row]
+        psi_row = state.rational_psi[row]
         min_dist = Inf
         for row2 in 1:n_rational
             row2 == row && continue

--- a/src/Vacuum/DataTypes.jl
+++ b/src/Vacuum/DataTypes.jl
@@ -239,8 +239,7 @@ end
 3D toroidal surface geometry for vacuum boundary integral calculations.
 
 Built by toroidally extruding a 2D poloidal contour (`PlasmaGeometry`) and computing
-Cartesian coordinates, tangent vectors, normals, and differential area elements. Note
-that the gradient/area elements are scaled by dθ and dζ.
+Cartesian coordinates, tangent vectors, normals, and differential area elements.
 
 # Fields
 

--- a/src/Vacuum/Kernel3D.jl
+++ b/src/Vacuum/Kernel3D.jl
@@ -177,74 +177,35 @@ function get_singular_quadrature(PATCH_RAD::Int, RAD_DIM::Int, INTERP_ORDER::Int
 end
 
 """
-    laplace_single_layer(x_obs, x_src) -> Float64
+    laplace_kernel(ox, oy, oz, sx, sy, sz, nx, ny, nz) -> (single, double)
 
-Evaluate the Laplace single-layer (FxU) kernel between two 3D points. Returns
-0.0 if the observation point coincides with the source point to avoid singularity.
+Fused scalar-argument Laplace kernels for the 3D vacuum BIE.
 
-The single-layer kernel φ is the fundamental solution to Laplace's equation:
+Returns a tuple `(single, double)` where:
 
-```
-φ(x_obs, x_src) = 1 / |x_obs - x_src|
-```
+  - `single = 1/r` is the single-layer kernel
+  - `double = (Δx⋅n)/r^3` is the double-layer kernel
 
-# Arguments
-
-  - `x_obs`: Observation point (3D Cartesian coordinates, any AbstractVector)
-  - `x_src`: Source point (3D Cartesian coordinates, any AbstractVector)
-
-# Returns
-
-  - `Float64`: Kernel value φ(x_obs, x_src)
+This is used when `compute_3D_kernel_matrices!` needs **both** kernels for the same pair, so the
+distance computation (`sqrt(r²)`) is shared. Returns `(0.0, 0.0)` when `r² < 1e-30`.
 """
-function laplace_single_layer(x_obs::AbstractVector{<:Real}, x_src::AbstractVector{<:Real})
-    @inbounds begin
-        dx = x_obs[1] - x_src[1]
-        dy = x_obs[2] - x_src[2]
-        dz = x_obs[3] - x_src[3]
-    end
+@fastmath @inline function laplace_kernel(
+    ox::Float64, oy::Float64, oz::Float64,
+    sx::Float64, sy::Float64, sz::Float64,
+    nx::Float64, ny::Float64, nz::Float64
+)
+    dx = ox - sx
+    dy = oy - sy
+    dz = oz - sz
     r2 = dx*dx + dy*dy + dz*dz
-    r2 < 1e-30 && return 0.0
-    return inv(sqrt(r2))
-end
-
-"""
-    laplace_double_layer(x_obs, x_src, n_src) -> Float64
-
-Evaluate the Laplace double-layer (DxU) kernel between a point and a surface element. Returns
-0.0 if the observation point coincides with the source point to avoid singularity. Allocation-free
-scalar arithmetic is used for maximum performance.
-
-The double-layer kernel K is the normal derivative of the fundamental solution:
-
-```
-K(x_obs, x_src, n_src) = ∇_{x_src} φ · n_src = (x_obs - x_src) · n_src / |x_obs - x_src|³
-```
-
-# Arguments
-
-  - `x_obs`: Observation point (3D Cartesian coordinates, any AbstractVector)
-  - `x_src`: Source point on surface (3D Cartesian coordinates, any AbstractVector)
-  - `n_src`: Outward UNIT normal at source point (must be normalized!, any AbstractVector)
-
-# Returns
-
-  - `Float64`: Kernel value K(x_obs, x_src, n_src)
-"""
-function laplace_double_layer(x_obs::AbstractVector{<:Real}, x_src::AbstractVector{<:Real}, n_src::AbstractVector{<:Real})
-    @inbounds begin
-        dx = x_obs[1] - x_src[1]
-        dy = x_obs[2] - x_src[2]
-        dz = x_obs[3] - x_src[3]
-        nx = n_src[1]
-        ny = n_src[2]
-        nz = n_src[3]
-    end
-    r2 = dx*dx + dy*dy + dz*dz
-    r2 < 1e-30 && return 0.0
+    r2 < 1e-30 && return (0.0, 0.0)
     rinv = inv(sqrt(r2))
+    # single-layer: 1/r
+    single = rinv
+    # double-layer: (Δx·n)/r^3
     r3inv = rinv * rinv * rinv
-    return (dx*nx + dy*ny + dz*nz) * r3inv
+    double = (dx*nx + dy*ny + dz*nz) * r3inv
+    return (single, double)
 end
 
 """
@@ -281,8 +242,7 @@ end
     interpolate_to_polar!(polar_data, patch, quad_data)
 
 Interpolate Cartesian patch data to polar quadrature points using sparse matrix multiply.
-Overwrites `polar_data` using mul! function arguments, mul!(C, A, B, α, β) -> C where
-C = α * A * B + β * C.
+Overwrites `polar_data` using mul! function arguments, mul!(C, A, B) -> C where C = A * B.
 
 # Arguments
 
@@ -291,13 +251,12 @@ C = α * A * B + β * C.
   - `P2G`: Sparse interpolation matrix
 """
 function interpolate_to_polar!(polar_data::Array{Float64,3}, patch::Array{Float64,3}, P2G::SparseMatrixCSC{Float64,Int})
-    # Flatten patch to (Ngrid × dof), apply P2G' to get (Npolar × dof)
     patch_flat = reshape(patch, :, size(patch, 3))
-    mul!(reshape(polar_data, :, size(patch, 3)), P2G', patch_flat, 1.0, 0.0)
+    mul!(reshape(polar_data, :, size(patch, 3)), P2G', patch_flat)
 end
 
 """
-    compute_polar_normal!(n_polar, dr_dθ_polar, dr_dζ_polar)
+    compute_polar_normal!(n_polar, dr_dθ_polar, dr_dζ_polar, normal_orient)
 
 Compute normal vector (= ∂r/∂θ × ∂r/∂ζ) at polar quadrature points from interpolated tangent vectors.
 We already scaled the normals by normal_orient in the geometry construction, so we need to reapply
@@ -380,12 +339,17 @@ where each entry is φ(x_obs, x_src).
   - `grad_greenfunction`: Double-layer kernel matrix (Nobs × Nsrc) filled in place
 
   - `greenfunction`: Single-layer kernel matrix (Nobs × Nsrc) filled in place
+
   - `observer`: Observer geometry (PlasmaGeometry3D)
+
   - `source`: Source geometry (PlasmaGeometry3D)
+
   - `PATCH_RAD`: Number of points adjacent to source point to treat as singular
 
       + Total patch size in # of gridpoints = (2 * PATCH_RAD + 1) x (2 * PATCH_RAD + 1)
+
   - `RAD_DIM`: Polar radial quadrature order. Angular order = 2 * RAD_DIM
+
   - `INTERP_ORDER`: Lagrange interpolation order
 
       + Must be ≤ (2 * PATCH_RAD + 1)
@@ -405,7 +369,7 @@ function compute_3D_kernel_matrices!(
     INTERP_ORDER::Int
 )
     num_points = observer.mtheta * observer.nzeta
-    dθdζ = 4π^2 / (num_points)
+    dθdζ = 4π^2 / num_points
 
     # Get block of grad green function matrix
     col_index = (source isa PlasmaGeometry3D ? 1 : 2)
@@ -424,13 +388,11 @@ function compute_3D_kernel_matrices!(
     # Initialize quadrature data
     # This allows the code to run at lower resolution without erroring out, but will warn the user.
     if PATCH_RAD > (min(source.mtheta, source.nzeta) - 1) ÷ 2
-        @warn "PATCH_RAD is greater than the number of points in the toroidal or poloidal direction, which is not supported. Setting PATCH_RAD to $((min(source.mtheta, source.nzeta) - 1) ÷ 2). Be sure to check if outputs are converged."
+        @warn "PATCH_RAD is greater than half the number of points in the toroidal or poloidal direction, which is not supported. Setting PATCH_RAD to $((min(source.mtheta, source.nzeta) - 1) ÷ 2). Be sure to check if outputs are converged."
         PATCH_RAD = (min(source.mtheta, source.nzeta) - 1) ÷ 2
     end
     quad_data = get_singular_quadrature(PATCH_RAD, RAD_DIM, INTERP_ORDER)
     (; PATCH_DIM, PATCH_RAD, ANG_DIM, RAD_DIM, Ppou, Gpou, P2G) = quad_data
-    @assert observer.mtheta ≥ PATCH_DIM "Must have observer.mtheta ≥ PATCH_DIM, got observer.mtheta=$(observer.mtheta), PATCH_DIM=$PATCH_DIM"
-    @assert observer.nzeta ≥ PATCH_DIM "Must have observer.nzeta ≥ PATCH_DIM, got observer.nzeta=$(observer.nzeta), PATCH_DIM=$PATCH_DIM"
 
     # Allocate thread-local workspaces (one per thread)
     max_threadid = Threads.maxthreadid()
@@ -456,14 +418,13 @@ function compute_3D_kernel_matrices!(
             # Evaluate kernels at grid points
             r_src = @view source.r[idx_src, :]
             n_src = @view source.normal[idx_src, :]
-            K_single = laplace_single_layer(r_obs, r_src)
-            K_double = laplace_double_layer(r_obs, r_src, n_src)
+            far_single, far_double = laplace_kernel(r_obs[1], r_obs[2], r_obs[3], r_src[1], r_src[2], r_src[3], n_src[1], n_src[2], n_src[3])
 
             # Apply weights (periodic trapezoidal rule = constant weights)
             if populate_greenfunction
-                greenfunction[idx_obs, idx_src] = K_single * dθdζ
+                greenfunction[idx_obs, idx_src] = far_single * dθdζ
             end
-            grad_greenfunction_block[idx_obs, idx_src] = K_double * dθdζ
+            grad_greenfunction_block[idx_obs, idx_src] = far_double * dθdζ
         end
 
         # ============================================================
@@ -482,28 +443,28 @@ function compute_3D_kernel_matrices!(
         # Compute normal vectors at polar points from interpolated tangent vectors
         compute_polar_normal!(n_polar, dr_dθ_polar, dr_dζ_polar, source.normal_orient)
 
-        # Evaluate kernels at polar points with POU weighting
+        # Evaluate kernels and apply quadrature weights: area element × POU, where POU contains rdrdθ already
         @inbounds for ia in 1:ANG_DIM, ir in 1:RAD_DIM
             # Evaluate kernels using recomputed normal (use @view to avoid allocation)
             r_src = @view r_polar[ir, ia, :]
             n_src = @view n_polar[ir, ia, :]
-            K_single = laplace_single_layer(r_obs, r_src)
-            K_double = laplace_double_layer(r_obs, r_src, n_src)
+            near_single, near_double = laplace_kernel(r_obs[1], r_obs[2], r_obs[3], r_src[1], r_src[2], r_src[3], n_src[1], n_src[2], n_src[3])
 
             # Apply quadrature weights: area element × POU, where POU contains rdrdθ already
-            M_polar_single[ir, ia] = K_single * Ppou[ir, ia] * dθdζ
-            M_polar_double[ir, ia] = K_double * Ppou[ir, ia] * dθdζ
+            M_polar_single[ir, ia] = near_single * Ppou[ir, ia] * dθdζ
+            M_polar_double[ir, ia] = near_double * Ppou[ir, ia] * dθdζ
         end
 
         # Distribute polar singular corrections back to Cartesian grid using sparse matrix
         # grid = P2G * polar (maps Npolar → Ngrid)
-        mul!(M_grid_single_flat, P2G, vec(M_polar_single))
         mul!(M_grid_double_flat, P2G, vec(M_polar_double))
-        M_grid_single = reshape(M_grid_single_flat, PATCH_DIM, PATCH_DIM)
         M_grid_double = reshape(M_grid_double_flat, PATCH_DIM, PATCH_DIM)
+        if populate_greenfunction
+            mul!(M_grid_single_flat, P2G, vec(M_polar_single))
+            M_grid_single = reshape(M_grid_single_flat, PATCH_DIM, PATCH_DIM)
+        end
 
-        # Compute remaining far-field POU contribution and near-field polar quadrature result
-        # We include this region in the far-field trapezoidal rule, so use Gpou = -χ here to get 1-χ
+        # POU correction: singular correction + (1 + Gpou) * far-field terms
         @inbounds for j in 1:PATCH_DIM, i in 1:PATCH_DIM
             # Map back to global indices
             idx_pol = periodic_wrap(i_obs - PATCH_RAD + i - 1, source.mtheta)
@@ -513,14 +474,13 @@ function compute_3D_kernel_matrices!(
             # Remainder of far-field contribution on the singular grid: Gpou = -χ
             r_src = @view source.r[idx_src, :]
             n_src = @view source.normal[idx_src, :]
-            far_single = laplace_single_layer(r_obs, r_src) * Gpou[i, j] * dθdζ
-            far_double = laplace_double_layer(r_obs, r_src, n_src) * Gpou[i, j] * dθdζ
+            far_single, far_double = laplace_kernel(r_obs[1], r_obs[2], r_obs[3], r_src[1], r_src[2], r_src[3], n_src[1], n_src[2], n_src[3])
 
             # Apply near + far contributions
             if populate_greenfunction
-                greenfunction[idx_obs, idx_src] += M_grid_single[i, j] + far_single
+                greenfunction[idx_obs, idx_src] += M_grid_single[i, j] + far_single * Gpou[i, j] * dθdζ
             end
-            grad_greenfunction_block[idx_obs, idx_src] += M_grid_double[i, j] + far_double
+            grad_greenfunction_block[idx_obs, idx_src] += M_grid_double[i, j] + far_double * Gpou[i, j] * dθdζ
         end
     end
 
@@ -530,7 +490,7 @@ function compute_3D_kernel_matrices!(
     greenfunction ./= 2π
 
     # Add the term that comes from the volume integral of Green's identity
-    typeof(source) == typeof(observer) && begin
+    if typeof(source) == typeof(observer)
         for i in 1:num_points
             grad_greenfunction_block[i, i] += 1.0
         end

--- a/src/Vacuum/Kernel3D.jl
+++ b/src/Vacuum/Kernel3D.jl
@@ -385,12 +385,13 @@ function compute_3D_kernel_matrices!(
     # 𝒢ⁿ only needed for plasma as source term (RHS of eqs. 26/27 in Chance 1997)
     populate_greenfunction = source isa PlasmaGeometry3D
 
-    # Initialize quadrature data
     # This allows the code to run at lower resolution without erroring out, but will warn the user.
     if PATCH_RAD > (min(source.mtheta, source.nzeta) - 1) ÷ 2
-        @warn "PATCH_RAD is greater than half the number of points in the toroidal or poloidal direction, which is not supported. Setting PATCH_RAD to $((min(source.mtheta, source.nzeta) - 1) ÷ 2). Be sure to check if outputs are converged."
+        @warn "PATCH_RAD=$(PATCH_RAD) is greater than half the number of points in the toroidal or poloidal direction, which is not supported. Setting PATCH_RAD to $((min(source.mtheta, source.nzeta) - 1) ÷ 2), be sure to check if outputs are converged. This can be avoided by setting mtheta and nzeta to be greater than $(2 * PATCH_RAD + 1)."
         PATCH_RAD = (min(source.mtheta, source.nzeta) - 1) ÷ 2
     end
+
+    # Initialize quadrature data
     quad_data = get_singular_quadrature(PATCH_RAD, RAD_DIM, INTERP_ORDER)
     (; PATCH_DIM, PATCH_RAD, ANG_DIM, RAD_DIM, Ppou, Gpou, P2G) = quad_data
 

--- a/src/Vacuum/Utilities.jl
+++ b/src/Vacuum/Utilities.jl
@@ -140,11 +140,11 @@ Inline function for fast cross product of two 3D vectors at a given index.
     idx::Int
 )
     @inbounds begin
-        a1 = a[idx, 1];
-        a2 = a[idx, 2];
+        a1 = a[idx, 1]
+        a2 = a[idx, 2]
         a3 = a[idx, 3]
-        b1 = b[idx, 1];
-        b2 = b[idx, 2];
+        b1 = b[idx, 1]
+        b2 = b[idx, 2]
         b3 = b[idx, 3]
 
         c[idx, 1] = a2*b3 - a3*b2

--- a/src/Vacuum/Vacuum.jl
+++ b/src/Vacuum/Vacuum.jl
@@ -24,8 +24,7 @@ export extract_plasma_surface_at_psi
 export PlasmaGeometry
 
 """
-    compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings;
-        green_only=false)
+    compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings)
 
 Compute the vacuum response matrix and both Green's functions using provided vacuum inputs.
 
@@ -47,7 +46,6 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
 
   - `inputs`: `VacuumInput` struct with mode numbers, grid resolution, and boundary info.
   - `wall_settings::WallShapeSettings`: Wall geometry configuration.
-  - `green_only`: If true, skip building the response matrix `wv` and return zeros for `wv` and `xzpts`.
 
 # Returns
 
@@ -71,8 +69,7 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
     wall_pts::AbstractMatrix{Float64},
     inputs::VacuumInput,
     wall_settings::WallShapeSettings;
-    n_override::Union{Nothing,Int}=nothing,
-    green_only::Bool=false
+    n_override::Union{Nothing,Int}=nothing
 )
 
     # Initialize surface geometries
@@ -139,48 +136,42 @@ It computes both interior (grri) and exterior (grre) Green's functions for GPEC 
     F_int = lu!(grad_green_interior)
     ldiv!(F_int, grri)
 
-    # Always initialise wv to zero so that green_only keeps it zeroed
-    if !green_only
-        # Perform inverse Fourier transforms to get response matrix components [Chance Phys. Plasmas 2007 052506 eq. 115-118]
-        arr, aii, ari, air = ntuple(_ -> zeros(num_modes, num_modes), 4)
-        fourier_inverse_transform!(arr, grre, cos_mn_basis)
-        fourier_inverse_transform!(aii, grre, sin_mn_basis; col_offset=num_modes)
-        fourier_inverse_transform!(ari, grre, sin_mn_basis)
-        fourier_inverse_transform!(air, grre, cos_mn_basis; col_offset=num_modes)
+    # Perform inverse Fourier transforms to get response matrix components [Chance Phys. Plasmas 2007 052506 eq. 115-118]
+    arr, aii, ari, air = ntuple(_ -> zeros(num_modes, num_modes), 4)
+    fourier_inverse_transform!(arr, grre, cos_mn_basis)
+    fourier_inverse_transform!(aii, grre, sin_mn_basis; col_offset=num_modes)
+    fourier_inverse_transform!(ari, grre, sin_mn_basis)
+    fourier_inverse_transform!(air, grre, cos_mn_basis; col_offset=num_modes)
 
-        # fourier_inverse_transform! uses 1/N normalization; restore the 4π² physics factor
-        # from the vacuum Green's function integral [Chance 2007 eq. 114-118]
-        arr .*= 4π^2
-        aii .*= 4π^2
-        ari .*= 4π^2
-        air .*= 4π^2
+    # fourier_inverse_transform! uses 1/N normalization; restore the 4π² physics factor
+    # from the vacuum Green's function integral [Chance 2007 eq. 114-118]
+    arr .*= 4π^2
+    aii .*= 4π^2
+    ari .*= 4π^2
+    air .*= 4π^2
 
-        # Final form of vacuum response matrix [Chance Phys. Plasmas 2007 052506 eq. 114]
-        wv .= complex.(arr .+ aii, air .- ari)
-        inputs.force_wv_symmetry && hermitianpart!(wv)
+    # Final form of vacuum response matrix [Chance Phys. Plasmas 2007 052506 eq. 114]
+    wv .= complex.(arr .+ aii, air .- ari)
+    inputs.force_wv_symmetry && hermitianpart!(wv)
 
-        # Fill coordinate arrays
-        if inputs.nzeta > 1 # 3D
-            plasma_pts .= plasma_surf.r
-            wall_pts .= wall.r
-        else # 2D
-            @views begin
-                plasma_pts[:, 1] .= plasma_surf.x
-                plasma_pts[:, 2] .= 0.0
-                plasma_pts[:, 3] .= plasma_surf.z
-                wall_pts[:, 1] .= wall.x
-                wall_pts[:, 2] .= 0.0
-                wall_pts[:, 3] .= wall.z
-            end
+    # Fill coordinate arrays
+    if inputs.nzeta > 1 # 3D
+        plasma_pts .= plasma_surf.r
+        wall_pts .= wall.r
+    else # 2D
+        @views begin
+            plasma_pts[:, 1] .= plasma_surf.x
+            plasma_pts[:, 2] .= 0.0
+            plasma_pts[:, 3] .= plasma_surf.z
+            wall_pts[:, 1] .= wall.x
+            wall_pts[:, 2] .= 0.0
+            wall_pts[:, 3] .= wall.z
         end
     end
 end
 
 """
-    compute_vacuum_response(
-        inputs::VacuumInput,
-        wall_settings::WallShapeSettings;
-        green_only=false)
+    compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings)
 
 Allocate and return the vacuum response matrix and Green's functions for the given
 vacuum inputs.
@@ -190,12 +181,12 @@ implementation. For performance‑critical paths that already own preallocated s
 (e.g. `ForceFreeStates.VacuumData`), prefer the in‑place method to avoid extra
 heap allocations.
 """
-@with_pool pool function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings; green_only::Bool=false)
+@with_pool pool function compute_vacuum_response(inputs::VacuumInput, wall_settings::WallShapeSettings)
 
     # Allocate storage for the vacuum response matrix and Green's functions
     numpoints = inputs.mtheta * inputs.nzeta
     num_modes = inputs.mpert * inputs.npert
-    
+
     vac = (
         wv=zeros(ComplexF64, num_modes, num_modes),
         grri=zeros(2 * numpoints, 2 * num_modes),
@@ -203,17 +194,13 @@ heap allocations.
         plasma_pts=zeros(numpoints, 3),
         wall_pts=zeros(numpoints, 3)
     )
-    compute_vacuum_response!(vac, inputs, wall_settings; green_only=green_only)
+    compute_vacuum_response!(vac, inputs, wall_settings)
 
     return vac.wv, vac.grri, vac.grre, vac.plasma_pts, vac.wall_pts
 end
 
 """
-    compute_vacuum_response!(
-        vac_data,
-        inputs::VacuumInput,
-        wall_settings::WallShapeSettings;
-        green_only=false)
+    compute_vacuum_response!(vac_data, inputs::VacuumInput, wall_settings::WallShapeSettings)
 
 In-place variant that computes the vacuum response and directly populates the arrays
 stored in `vac_data`.
@@ -230,7 +217,7 @@ compatible sizes:
 This is designed to work with `ForceFreeStates.VacuumData` but does not depend on
 its concrete type (duck-typed on field names only).
 """
-function compute_vacuum_response!(vac_data, inputs::VacuumInput, wall_settings::WallShapeSettings; green_only::Bool=false)
+function compute_vacuum_response!(vac_data, inputs::VacuumInput, wall_settings::WallShapeSettings)
 
     mpert = inputs.mpert
     npert = inputs.npert
@@ -245,8 +232,7 @@ function compute_vacuum_response!(vac_data, inputs::VacuumInput, wall_settings::
             vac_data.plasma_pts,
             vac_data.wall_pts,
             inputs,
-            wall_settings;
-            green_only=green_only
+            wall_settings
         )
     else
         # 2D vacuum: fill diagonal blocks of the response matrix
@@ -270,8 +256,7 @@ function compute_vacuum_response!(vac_data, inputs::VacuumInput, wall_settings::
                 vac_data.wall_pts,
                 inputs,
                 wall_settings;
-                n_override=n,
-                green_only=green_only
+                n_override=n
             )
         end
     end

--- a/test/runtests_vacuum.jl
+++ b/test/runtests_vacuum.jl
@@ -658,36 +658,12 @@
             @test isapprox(wv, wv', rtol=1e-12)
         end
 
-        @testset "compute_vacuum_response 3D green_only" begin
-            inputs = _make_3d_inputs(mtheta=32, nzeta=32, mtheta_eq=17)
-            wall_settings = WallShapeSettings(shape="nowall")
-            wv, grri, grre, plasma_pts, wall_pts = compute_vacuum_response(inputs, wall_settings; green_only=true)
-
-            numpoints = inputs.mtheta * inputs.nzeta
-            num_modes = inputs.mpert * inputs.npert
-            @test size(wv) == (num_modes, num_modes)
-            @test all(wv .== 0)
-            @test size(grri) == (2 * numpoints, 2 * num_modes)
-            @test size(grre) == (2 * numpoints, 2 * num_modes)
-            @test all(isfinite, grri)
-            @test all(isfinite, grre)
-        end
-
-        @testset "Kernel3D laplace_single_layer" begin
-            x_obs = [1.0, 0.0, 0.0]
-            x_src = [2.0, 0.0, 0.0]
-            G = GeneralizedPerturbedEquilibrium.Vacuum.laplace_single_layer(x_obs, x_src)
+        @testset "Kernel3D laplace_kernel" begin
+            G, K = GeneralizedPerturbedEquilibrium.Vacuum.laplace_kernel(1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 0.0)
             # Kernel returns 1/|r_obs - r_src| (4π factor applied elsewhere in BIE)
             dist = sqrt((2.0 - 1.0)^2 + 0 + 0)
             @test isapprox(G, 1.0 / dist)
             @test isfinite(G)
-        end
-
-        @testset "Kernel3D laplace_double_layer" begin
-            x_obs = [1.0, 0.0, 0.0]
-            x_src = [2.0, 0.0, 0.0]
-            n_src = [1.0, 0.0, 0.0]  # normal pointing away from source
-            K = GeneralizedPerturbedEquilibrium.Vacuum.laplace_double_layer(x_obs, x_src, n_src)
             @test K isa Float64
             @test isfinite(K)
         end


### PR DESCRIPTION
This branch consists of cleanups that I made in #190 that can go in the main branch before I close that PR. They are all almost entirely cosmetic and improve the transparency of the code.

I deprecated the `green_only` parameter after doing some benchmarks and finding that the response matrix construction takes less than 1% of runtime, so the additional complexity wasn't worth it

I also cleaned up the 3D Solovev example, including adding back in `nzvac > 1` which was accidentally removed by Claude at some point.