### PR TITLE
Ballooning Optimizations

### DIFF
--- a/docs/src/ballooning.md
+++ b/docs/src/ballooning.md
@@ -844,6 +844,10 @@ a_2\left(\theta+\frac{a_1}{2a_2}\right)^2
 The residual scale is ``c = a_0-a_1^2/(4a_2)``. To make the asymptotic
 approximation valid, the code chooses an integration boundary where the
 ``\theta^2`` term dominates, using the scale ``\sqrt{|c/a_2|}``.
+Because the shooting boundary is a single flux-surface quantity, `Bal.jl`
+evaluates this scale on the ballooning theta grid and uses the largest finite
+value on that surface. The base integration boundary is then capped as
+``\theta_{\max}=\min(16.5,10\max_\theta\sqrt{|c/a_2|})``.
 
 Directly extracting ``c_{a1}`` or ``\Delta'`` from the small asymptotic solution is
 numerically fragile. The comparison below shows that the `Baloo.f` style, which

--- a/examples/DIIID-like_ideal_example/gpec.toml
+++ b/examples/DIIID-like_ideal_example/gpec.toml
@@ -43,7 +43,6 @@ nn_high = 1                    # Largest toroidal mode number to include
 delta_mlow = 8                 # Expands lower bound of Fourier harmonics
 delta_mhigh = 8                # Expands upper bound of Fourier harmonics
 mthvac = 512                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                     # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"       # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0           # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/LAR_beta_scan/gpec.toml
+++ b/examples/LAR_beta_scan/gpec.toml
@@ -48,7 +48,6 @@ nn_high      = 1               # Largest toroidal mode number to include
 delta_mlow   = 8               # Expands lower bound of Fourier harmonics
 delta_mhigh  = 8               # Expands upper bound of Fourier harmonics
 mthvac       = 960             # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0       = 1               # Linear multiplier on the automatic choice of theta integration bounds
 
 eulerlagrange_tolerance = 1e-12 # Relative tolerance for ODE integration of Euler-Lagrange equations
 singfac_min             = 1e-4 # Fractional distance from rational q at which ideal jump enforced

--- a/examples/LAR_epsilon_scan/gpec.toml
+++ b/examples/LAR_epsilon_scan/gpec.toml
@@ -49,7 +49,6 @@ nn_high      = 1               # Largest toroidal mode number to include
 delta_mlow   = 8               # Expands lower bound of Fourier harmonics
 delta_mhigh  = 8               # Expands upper bound of Fourier harmonics
 mthvac       = 960             # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0       = 1               # Linear multiplier on the automatic choice of theta integration bounds
 
 eulerlagrange_tolerance = 1e-12 # Relative tolerance for ODE integration of Euler-Lagrange equations
 singfac_min             = 1e-4 # Fractional distance from rational q at which ideal jump enforced

--- a/examples/Solovev_ideal_example/gpec.toml
+++ b/examples/Solovev_ideal_example/gpec.toml
@@ -60,7 +60,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
 mthvac = 960                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/Solovev_ideal_example_3D/gpec.toml
+++ b/examples/Solovev_ideal_example_3D/gpec.toml
@@ -31,7 +31,6 @@ delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
 nzvac = 96                    # Number of points used in splines over toroidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/Solovev_ideal_example_multi_n/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/gpec.toml
@@ -42,7 +42,6 @@ nn_high = 2                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
 mthvac = 960                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/Solovev_ideal_example_multi_n/single_n_1/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/single_n_1/gpec.toml
@@ -41,7 +41,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 10              # Expands upper bound of Fourier harmonics
 mthvac = 960                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/Solovev_ideal_example_multi_n/single_n_2/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/single_n_2/gpec.toml
@@ -41,7 +41,6 @@ nn_high = 2                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
 mthvac = 960                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/examples/Solovev_kinetic_calculated_example/gpec.toml
+++ b/examples/Solovev_kinetic_calculated_example/gpec.toml
@@ -40,7 +40,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 8                # Expands lower bound of Fourier harmonics
 delta_mhigh = 8               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at plasma-vacuum interface.
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "calculated" # Kinetic matrix source — exercises KineticForces.compute_calculated_kinetic_matrices callback with real physics
 kinetic_factor = 1.0          # Full-strength kinetic matrices (the "calculated" path is the real physics; no perturbation scaling)

--- a/examples/a10_kinetic_example/gpec.toml
+++ b/examples/a10_kinetic_example/gpec.toml
@@ -38,7 +38,6 @@ nn_high = 1                    # Largest toroidal mode number to include
 delta_mlow = 6                 # Expands lower bound of Fourier harmonics
 delta_mhigh = 6                # Expands upper bound of Fourier harmonics
 mthvac = 512                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                     # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "calculated"  # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 1.0           # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode; 1.0 = full strength)

--- a/src/ForceFreeStates/Ballooning.jl
+++ b/src/ForceFreeStates/Ballooning.jl
@@ -3,6 +3,7 @@
 #   Computes ballooning stability criterion over all flux surfaces
 # ======================================================================
 using LinearAlgebra
+using StaticArrays: SVector
 
 """
     compute_ballooning_stability!(ctrl, locstab_fs, plasma_eq)
@@ -476,7 +477,10 @@ function prepare_ballooning_coefficients(
     kappaw_periodic .+= -kappas .* i_per_perturbed .+ (theta_k_reference .* q_derivative .+ i_per0_thetak_shift) .* kappas
     kappaw_secular = q_derivative .* kappas
 
-    bf_fs = zeros(mtheta + 1, 9)
+    # Only the 7 coefficients the ballooning ODE RHS reads are interpolated. bsq and sigma are kept as
+    # locals (used below for n0_fs/d0bar) but deliberately NOT added to the spline, since the RHS never
+    # uses them — interpolating 9 columns when 7 suffice wastes ~22% of every per-step spline evaluation.
+    bf_fs = zeros(mtheta + 1, 7)
     bf_fs[:, 1] = nabla_beta_sq_b_sq_periodic
     bf_fs[:, 2] = nabla_beta_sq_b_sq_peculiar_1st
     bf_fs[:, 3] = nabla_beta_sq_b_sq_peculiar_2nd
@@ -484,10 +488,8 @@ function prepare_ballooning_coefficients(
     bf_fs[:, 5] = kappaw_secular
     bf_fs[:, 6] = jac_chiprime
     bf_fs[:, 7] = pprime_chiprime
-    bf_fs[:, 8] = bsq
 
     sigma = .-(two_pi_f .* pressure_gradient .* q_derivative) ./ (chi_prime^2 .* bsq)
-    bf_fs[:, 9] = sigma
 
     m0_12 = jac_chiprime ./ nabla_beta_sq_b_sq_peculiar_2nd
     m0_21 = -2.0 .* jac_chiprime .* pprime_chiprime .* kappaw_periodic
@@ -1099,8 +1101,8 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
     theta_start_right = THETA_MAX0
     theta_end_right = MATCHING_POINT
 
-    initial_condition_left = [0.0, 1.0]
-    initial_condition_right = [0.0, -1.0]
+    initial_condition_left = SVector(0.0, 1.0)
+    initial_condition_right = SVector(0.0, -1.0)
 
     # Reusable RHS parameters: precompute the periodic-wrap constants once (were recomputed every RHS call)
     # and carry a scratch buffer + search hint so the spline is evaluated in place (no per-step allocation).
@@ -1111,7 +1113,7 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
 
     # Only the endpoint log-derivative is used, so don't store the full trajectory or build dense output.
     problem_left = ODEProblem(
-        compute_ballooning_ode!,
+        compute_ballooning_ode,
         initial_condition_left,
         (theta_start_left, theta_end_left),
         ode_params
@@ -1132,7 +1134,7 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
     end
 
     problem_right = ODEProblem(
-        compute_ballooning_ode!,
+        compute_ballooning_ode,
         initial_condition_right,
         (theta_start_right, theta_end_right),
         ode_params
@@ -1165,7 +1167,7 @@ end
 #   Differential equations for marginal ballooning stability
 # ======================================================================
 """
-    compute_ballooning_ode!(derivatives, solution, parameters, poloidal_angle)
+    compute_ballooning_ode(solution, parameters, poloidal_angle) -> SVector{2,Float64}
 
 Defines the RHS of the first-order ODE system for ideal marginal ballooning modes.
 Used by the DifferentialEquations.jl ODE solver.
@@ -1179,12 +1181,11 @@ where y₁ is the solution and y₂ = f·dy/dθ.
 
 ## Arguments
 
-  - `derivatives::Vector{Float64}`: Output vector [dy₁/dθ, dy₂/dθ].
-  - `solution::Vector{Float64}`: Current state vector [y₁, y₂].
+  - `solution`: Current state vector `[y₁, y₂]` (an `SVector{2}`). Returns the derivative `[dy₁/dθ, dy₂/dθ]` as an `SVector{2}`.
   - `parameters::Tuple`: (ode_coefficient_spline, reference_angle).
   - `poloidal_angle::Float64`: Current poloidal angle θ (independent variable).
 """
-function compute_ballooning_ode!(derivatives, solution, parameters, poloidal_angle)
+function compute_ballooning_ode(solution, parameters, poloidal_angle)
     itp = parameters.itp
     coeffs = parameters.coeffs
     theta_wrapped = mod(Float64(poloidal_angle) - parameters.theta_min, parameters.theta_period) + parameters.theta_min
@@ -1204,6 +1205,7 @@ function compute_ballooning_ode!(derivatives, solution, parameters, poloidal_ang
     kappaw = kappaw_periodic - poloidal_angle * kappaw_secular
     g = -2.0 * jac_chiprime * pprime_chiprime * kappaw
 
-    derivatives[1] = solution[2] / f
-    derivatives[2] = g * solution[1]
+    # Out-of-place RHS returning an SVector: DP5 runs the 2-component system on stack-allocated static
+    # vectors (no heap, SIMD), removing the per-step Vector overhead of the integration.
+    return SVector(solution[2] / f, g * solution[1])
 end

--- a/src/ForceFreeStates/Ballooning.jl
+++ b/src/ForceFreeStates/Ballooning.jl
@@ -40,8 +40,10 @@ function compute_ballooning_stability!(
 
     num_psi = length(plasma_eq.profiles.xs)
 
-    # Loop over flux surfaces
-    for flux_surface_index in 1:num_psi
+    # Parallelism is governed by the Julia thread count (`julia -t N`); with one thread this runs serially.
+    # All data is thread-local, so no locks are needed. The `:greedy` scheduling strategy
+    # outperforms `:static` and `:dynamic` for this workload in testing.
+    Threads.@threads :greedy for flux_surface_index in 1:num_psi
 
         psi = plasma_eq.profiles.xs[flux_surface_index]
         coeff_data = prepare_ballooning_coefficients(flux_surface_index, plasma_eq; theta_k=theta_k)

--- a/src/ForceFreeStates/Ballooning.jl
+++ b/src/ForceFreeStates/Ballooning.jl
@@ -5,6 +5,10 @@
 using LinearAlgebra
 using StaticArrays: SVector
 
+const BALLOONING_THETA_MAX_CAP = 16.5
+const BALLOONING_THETA_SCALE_MULTIPLIER = 10.0
+const MATCHING_POINT = 1e-3
+
 """
     compute_ballooning_stability!(ctrl, locstab_fs, plasma_eq)
 
@@ -374,6 +378,26 @@ function _calculate_i_per_perturbed(
     return i_per_perturbed
 end
 
+function _ballooning_theta_scale(
+    periodic::AbstractVector,
+    peculiar_1st::AbstractVector,
+    peculiar_2nd::AbstractVector;
+    fallback::Float64=BALLOONING_THETA_MAX_CAP
+)
+    theta_scale = 0.0
+    for idx in eachindex(periodic, peculiar_1st, peculiar_2nd)
+        a0 = periodic[idx]
+        a1 = peculiar_1st[idx]
+        a2 = peculiar_2nd[idx]
+        if Base.isfinite(a0) && Base.isfinite(a1) && Base.isfinite(a2) && Base.abs(a2) > Base.eps(Float64)
+            c = a0 - a1^2 / (4.0 * a2)
+            local_scale = Base.sqrt(Base.abs(c / a2))
+            Base.isfinite(local_scale) && (theta_scale = Base.max(theta_scale, local_scale))
+        end
+    end
+    return theta_scale > 0.0 ? theta_scale : fallback
+end
+
 function prepare_ballooning_coefficients(
     flux_surface_index::Int,
     plasma_eq::Equilibrium.PlasmaEquilibrium;
@@ -491,6 +515,13 @@ function prepare_ballooning_coefficients(
     bf_fs[:, 6] = jac_chiprime
     bf_fs[:, 7] = pprime_chiprime
 
+    theta_scale = _ballooning_theta_scale(
+        nabla_beta_sq_b_sq_periodic,
+        nabla_beta_sq_b_sq_peculiar_1st,
+        nabla_beta_sq_b_sq_peculiar_2nd
+    )
+    theta_max = min(BALLOONING_THETA_MAX_CAP, BALLOONING_THETA_SCALE_MULTIPLIER * theta_scale)
+
     sigma = .-(two_pi_f .* pressure_gradient .* q_derivative) ./ (chi_prime^2 .* bsq)
 
     m0_12 = jac_chiprime ./ nabla_beta_sq_b_sq_peculiar_2nd
@@ -512,7 +543,11 @@ function prepare_ballooning_coefficients(
     d0bar[2, 2] = n0_int[4]
 
     @views bf_fs[end, :] .= bf_fs[1, :]
-    ode_coefficient_spline = (xs=theta_grid, itp=cubic_interp(theta_grid, Series(bf_fs); bc=PeriodicBC()))
+    ode_coefficient_spline = (
+        xs=theta_grid,
+        itp=cubic_interp(theta_grid, Series(bf_fs); bc=PeriodicBC()),
+        theta_max=theta_max
+    )
 
     return (
         ode_coefficient_spline=ode_coefficient_spline,
@@ -1095,12 +1130,11 @@ Computes Delta' = (y'/y)_right - (y'/y)_left.
 function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
     TOLERANCE = 1e-8
     MINIMUM_STEP = 1e-10
-    MATCHING_POINT = 1e-3
-    THETA_MAX0 = 16.5
+    theta_max = max(ode_coefficient_spline.theta_max, 10.0 * MATCHING_POINT)
 
-    theta_start_left = -THETA_MAX0
+    theta_start_left = -theta_max
     theta_end_left = -MATCHING_POINT
-    theta_start_right = THETA_MAX0
+    theta_start_right = theta_max
     theta_end_right = MATCHING_POINT
 
     initial_condition_left = SVector(0.0, 1.0)

--- a/src/ForceFreeStates/Ballooning.jl
+++ b/src/ForceFreeStates/Ballooning.jl
@@ -1102,11 +1102,19 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
     initial_condition_left = [0.0, 1.0]
     initial_condition_right = [0.0, -1.0]
 
+    # Reusable RHS parameters: precompute the periodic-wrap constants once (were recomputed every RHS call)
+    # and carry a scratch buffer + search hint so the spline is evaluated in place (no per-step allocation).
+    itp = ode_coefficient_spline.itp
+    theta_min = first(ode_coefficient_spline.xs)
+    theta_period = last(ode_coefficient_spline.xs) - theta_min
+    ode_params = (itp=itp, coeffs=zeros(Float64, length(itp(theta_min))), theta_min=theta_min, theta_period=theta_period, hint=Ref(1))
+
+    # Only the endpoint log-derivative is used, so don't store the full trajectory or build dense output.
     problem_left = ODEProblem(
         compute_ballooning_ode!,
         initial_condition_left,
         (theta_start_left, theta_end_left),
-        (ode_coefficient_spline, theta_k)
+        ode_params
     )
     sol_left = solve(
         problem_left,
@@ -1115,6 +1123,8 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
         abstol=TOLERANCE^2,
         dtmin=MINIMUM_STEP,
         adaptive=true,
+        save_everystep=false,
+        dense=false,
         verbose=false
     )
     if sol_left.retcode != ReturnCode.Success
@@ -1125,7 +1135,7 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
         compute_ballooning_ode!,
         initial_condition_right,
         (theta_start_right, theta_end_right),
-        (ode_coefficient_spline, theta_k)
+        ode_params
     )
     sol_right = solve(
         problem_right,
@@ -1134,6 +1144,8 @@ function integrate_ballooning_ode(ode_coefficient_spline; theta_k::Float64=0.0)
         abstol=TOLERANCE^2,
         dtmin=MINIMUM_STEP,
         adaptive=true,
+        save_everystep=false,
+        dense=false,
         verbose=false
     )
     if sol_right.retcode != ReturnCode.Success
@@ -1173,11 +1185,12 @@ where y₁ is the solution and y₂ = f·dy/dθ.
   - `poloidal_angle::Float64`: Current poloidal angle θ (independent variable).
 """
 function compute_ballooning_ode!(derivatives, solution, parameters, poloidal_angle)
-    ode_coefficient_spline = parameters[1]
-    theta_min = first(ode_coefficient_spline.xs)
-    theta_period = last(ode_coefficient_spline.xs) - theta_min
-    theta_wrapped = mod(Float64(poloidal_angle) - theta_min, theta_period) + theta_min
-    coeffs = ode_coefficient_spline.itp(theta_wrapped)
+    itp = parameters.itp
+    coeffs = parameters.coeffs
+    theta_wrapped = mod(Float64(poloidal_angle) - parameters.theta_min, parameters.theta_period) + parameters.theta_min
+    # In-place spline evaluation into the reusable buffer; the plain `coeffs = itp(θ)` form allocated a
+    # fresh length-9 Vector on every RHS call — the dominant cost of the ballooning scan.
+    itp(coeffs, theta_wrapped; hint=parameters.hint)
 
     periodic = coeffs[1]
     peculiar_1st = coeffs[2]

--- a/src/ForceFreeStates/Ballooning.jl
+++ b/src/ForceFreeStates/Ballooning.jl
@@ -814,7 +814,7 @@ function ballooning_alpha_boundary(
     alpha = fill(NaN, npsi)
     alpha_critical = fill(NaN, npsi)
 
-    for i in 1:npsi
+    Threads.@threads :greedy for i in 1:npsi
         xs[i] > 1.0 && continue
         try
             alpha[i] = salpha_reference(i, plasma_eq).alpha_ref
@@ -878,7 +878,7 @@ function ballooning_alpha_boundaries(
     alpha_critical1 = fill(NaN, npsi)
     alpha_critical2 = fill(NaN, npsi)
 
-    for i in 1:npsi
+    Threads.@threads :greedy for i in 1:npsi
         xs[i] > 1.0 && continue
         try
             cr = ballooning_alpha_crossings(i, plasma_eq; theta_k=theta_k, max_alpha_scale=max_alpha_scale, n_scan=n_scan)
@@ -967,7 +967,7 @@ function ballooning_qprime_boundaries(
     qprime_critical1 = fill(NaN, npsi)
     qprime_critical2 = fill(NaN, npsi)
 
-    for i in 1:npsi
+    Threads.@threads :greedy for i in 1:npsi
         xs[i] > 1.0 && continue
         try
             cr = ballooning_qprime_crossings(

--- a/src/ForceFreeStates/ForceFreeStatesStructs.jl
+++ b/src/ForceFreeStates/ForceFreeStatesStructs.jl
@@ -214,7 +214,6 @@ A mutable struct containing control parameters for stability analysis, set by th
   - `nn_high::Int` - Upper bound for toroidal modes
   - `delta_mlow::Int` - Expands lower bound of Fourier harmonics by delta_mlow
   - `delta_mhigh::Int` - Expands upper bound of Fourier harmonics by delta_mhigh
-  - `thmax0::Float64` - Maximum integration step size (not yet implemented)
   - `nstep::Int` - Maximum number of integration steps (not yet implemented)
   - `ksing::Int` - Singular surface handling parameter
   - `eulerlagrange_tolerance::Float64` - Relative tolerance for ODE integration of Euler-Lagrange equations
@@ -259,7 +258,6 @@ A mutable struct containing control parameters for stability analysis, set by th
     nn_high::Int = 0
     delta_mlow::Int = 0
     delta_mhigh::Int = 0
-    thmax0::Float64 = 1.0
     nstep::Int = typemax(Int)
     ksing::Int = -1
     eulerlagrange_tolerance::Float64 = 1e-8

--- a/test/test_data/regression_solovev_ideal_example/gpec.toml
+++ b/test/test_data/regression_solovev_ideal_example/gpec.toml
@@ -40,7 +40,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/test/test_data/regression_solovev_ideal_example_multi_n/gpec.toml
+++ b/test/test_data/regression_solovev_ideal_example_multi_n/gpec.toml
@@ -40,7 +40,6 @@ nn_high = 2                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                  # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 0.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)

--- a/test/test_data/regression_solovev_kinetic_calculated/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_calculated/gpec.toml
@@ -41,7 +41,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "calculated" # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 1.0          # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode; 1.0 = full strength)

--- a/test/test_data/regression_solovev_kinetic_example/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_example/gpec.toml
@@ -40,7 +40,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 1e-9         # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode; tiny value just exercises the path)

--- a/test/test_data/regression_solovev_kinetic_multi_n/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_multi_n/gpec.toml
@@ -40,7 +40,6 @@ nn_high = 2                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "fixed"      # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
 kinetic_factor = 1e-9         # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode; tiny value just exercises the path)

--- a/test/test_data/regression_solovev_kinetic_nuzero/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_nuzero/gpec.toml
@@ -39,7 +39,6 @@ nn_high = 1                   # Largest toroidal mode number to include
 delta_mlow = 0                # Expands lower bound of Fourier harmonics
 delta_mhigh = 0               # Expands upper bound of Fourier harmonics
 mthvac = 64                   # Number of points used in splines over poloidal angle at plasma-vacuum interface.
-thmax0 = 1                    # Linear multiplier on the automatic choice of theta integration bounds
 
 kinetic_source = "calculated" # Kinetic matrix source — exercises KineticForces.compute_calculated_kinetic_matrices callback with real physics
 kinetic_factor = 1.0          # Full-strength kinetic matrices (the "calculated" path is the real physics; no perturbation scaling)


### PR DESCRIPTION
The new ballooning feature takes the vast majority of the runtime of the example cases now. There were a few trivial optimizations to make to reduce its runtime by ~60%. The primary one was fixing some repeated allocations in the ode solve. 

# Speedup timings:
---

## Isolated ballooning scaling on flux — current code

| threads          | `compute_ballooning_stability!` | `ballooning_alpha_boundary` | ballooning total | **× vs develop** |
| ---------------: | ------------------------------: | --------------------------: | ---------------: | ---------------: |
| develop (serial) | 1.58 s                          | 44.16 s                     | 45.74 s          | 1.0×             |
| 1                | 0.539 s                         | 14.79 s                     | 15.33 s          | **2.98×**        |
| 2                | 0.288 s                         | 7.75 s                      | 8.04 s           | **5.69×**        |
| 4                | 0.175 s                         | 4.77 s                      | 4.95 s           | **9.25×**        |
| 8                | 0.112 s                         | 2.94 s                      | 3.05 s           | **15.0×**        |
| 16               | 0.065 s                         | 1.79 s                      | 1.86 s           | **24.6×**        |
| 32               | 0.044 s                         | 1.37 s                      | 1.41 s           | **32.4×**        |


## Full DIII-D example (end-to-end `main`, warm)

| state (at 6 threads unless noted)                         | full `main` |
| --------------------------------------------------------- | ----------: |
| develop                                                   | 74.0 s      |
| + mem-alloc (commit #1)                                   | 52.9 s      |
| + SVector   (commit #2)                                   | 45.5 s      |
| + threading `compute` only (original one-liner)           | 45.0 s      |
| + threading `alpha_boundary` `:greedy` (current state)    | **34.1 s**  |
| current branch @ 1 thread (reference)                     | 50.2 s      |

---

Regression harness report:
```
================================================================
Case: diiid_n1 — DIII-D-like equilibrium, n=1, ideal + perturbed equilibrium
================================================================

Regression Report: diiid_n1
================================================================================================================
Ref 1: cfb7693  @ cfb76939 (2026-06-24)
Ref 2: local  @ local (2026-06-26)
----------------------------------------------------------------------------------------------------------------
Quantity                                      cfb7693          local            Diff               Status
----------------------------------------------------------------------------------------------------------------
root-area-weighted total energy Re(et[1])     1.535016e-15     1.535014e-15     2.5e-21            OK
root-area-weighted total energy Im(et[1])     -2.063679e-20    -3.238097e-20    1.2e-20            OK
root-area-weighted plasma energy Re(ep[1])    5.910651e-16     5.910593e-16     5.8e-21            OK
root-area-weighted vacuum energy Re(ev[1])    9.439628e-16     9.439622e-16     6.0e-22            OK
vacuum matrix min eigenvalue (XiNorm)         1.863758e-01     1.863758e-01     1.8e-13            OK
root-area-weighted plasma energy (all)        [35 elem]        [35 elem]        2.8e-17            OK
root-area-weighted vacuum energy (all)        [35 elem]        [35 elem]        9.3e-18            OK
root-area-weighted total energy (all)         [35 elem]        [35 elem]        4.5e-17            OK
ODE steps (saved)                             1278             1278             0.0e+00            OK
ODE steps (total)                             1966             1966             0.0e+00            OK
q0                                            1.209717e+00     1.209717e+00     0.0e+00            OK
q95                                           4.505011e+00     4.505011e+00     0.0e+00            OK
beta_t                                        1.301227e-02     1.301227e-02     0.0e+00            OK
beta_n                                        1.357940e+00     1.357940e+00     0.0e+00            OK
internal inductance li1                       1.046066e+00     1.046066e+00     0.0e+00            OK
internal inductance li2                       8.551636e-01     8.551636e-01     0.0e+00            OK
internal inductance li3                       8.879379e-01     8.879379e-01     0.0e+00            OK
poloidal beta betap1                          6.343911e-01     6.343911e-01     0.0e+00            OK
poloidal beta betap2                          5.186177e-01     5.186177e-01     0.0e+00            OK
poloidal beta betap3                          5.384938e-01     5.384938e-01     0.0e+00            OK
# singular surfaces                           5                5                0.0e+00            OK
singular psi locations                        [5 elem]         [5 elem]         0.0e+00            OK
singular q values                             [5 elem]         [5 elem]         0.0e+00            OK
current beta betaj                            4.252872e-01     4.252872e-01     0.0e+00            OK
plasma volume                                 1.945603e+01     1.945603e+01     0.0e+00            OK
plasma current                                1.205445e+00     1.205445e+00     0.0e+00            OK
mpert                                         35               35               0.0e+00            OK
npert                                         1                1                0.0e+00            OK
toroidal field bt0                            2.024475e+00     2.024475e+00     0.0e+00            OK
wall field bwall                              3.879849e-01     3.879849e-01     0.0e+00            OK
aspect ratio                                  2.702739e+00     2.702739e+00     0.0e+00            OK
elongation kappa                              1.658590e+00     1.658590e+00     0.0e+00            OK
q profile (checksum)                          dd3a12fb525e...  dd3a12fb525e...  identical          OK
pressure profile (checksum)                   e532229541b5...  e532229541b5...  identical          OK
Mercier D_I profile (checksum)                b8aa8e933417...  b8aa8e933417...  identical          OK
resistive interchange D_R profile (checksum)  b7c156d239c8...  b7c156d239c8...  identical          OK
ballooning Delta' profile (checksum)          a61852d006f7...  7e219728af0e...  0.000e+00 (0.00%)  ** CHANGED **
delta prime (BVP diagonal)                    [5 elem]         [5 elem]         9.1e-13            OK
island half-widths                            [5 elem]         [5 elem]         1.7e-16            OK
Chirikov parameter                            [5 elem]         [5 elem]         1.0e-14            OK
||resonant area-weighted field||              4.204598e-04     4.204598e-04     2.1e-18            OK
PE plasma energy                              3.721521e+00     3.721521e+00     8.9e-16            OK
PE vacuum energy                              3.459135e+00     3.459135e+00     1.3e-15            OK
PE surface energy                             5.576490e+00     5.576490e+00     4.4e-15            OK
PE toroidal torque                            4.584048e-02     4.584048e-02     6.7e-16            OK
Runtime (s)                                   166.3s           121.4s                              --
resonant area-weighted field b^r              [5 elem]         [5 elem]         1.7e-17            OK
================================================================================================================
Summary: 1 changed, 45 unchanged
```